### PR TITLE
1.2.0 SOTS Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+libs/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/SA.Content/Config/Config.cs
+++ b/SA.Content/Config/Config.cs
@@ -62,6 +62,11 @@ namespace StageAesthetic.Config
         public static ConfigEntry<bool> TitanicPlainsNostalgic { get; set; }
         public static ConfigEntry<bool> TitanicPlainsAbandoned { get; set; }
 
+        // Abodes
+        public static ConfigEntry<bool> ShatteredAbodesVanilla { get; set; }
+        public static ConfigEntry<bool> ShatteredAbodesSunny { get; set; }
+        public static ConfigEntry<bool> ShatteredAbodesAbandoned { get; set; }
+
         // Aqueduct
         public static ConfigEntry<bool> AbandonedAqueductVanilla { get; set; }
 
@@ -215,6 +220,10 @@ namespace StageAesthetic.Config
             DistantRoostAbyssal = SAConfig.Bind("Stages : Distant Roost", "Enable Distant Roost (Abyssal)?", true, "Texture swap to Red Abyssal Depths.");
 
             DistantRoostChanges = SAConfig.Bind("Stages : Distant Roost", "Alter Distant Roost (Vanilla)?", true, "Adds rain to the alt version.");
+
+            ShatteredAbodesVanilla = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Vanilla)?", true, "Disabling removes vanilla from getting picked");
+            ShatteredAbodesSunny = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Verdant)?", true, "Sunny and bright green.");
+            ShatteredAbodesAbandoned = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Abandoned)?", true, "Scorching Desert.");
 
             SiphonedForestVanilla = SAConfig.Bind("Stages : Siphoned Forest", "Enable Siphoned Forest (Vanilla)?", true, "Disabling removes vanilla from getting picked");
             SiphonedForestNight = SAConfig.Bind("Stages : Siphoned Forest", "Enable Siphoned Forest (Night)?", true, "Blue and dark.");
@@ -396,6 +405,7 @@ namespace StageAesthetic.Config
             distantRoostAltList = new();
             siphonedForestList = new();
             titanicPlainsList = new();
+            shatteredAbodesList = new();
 
             abandonedAqueductList = new();
             aphelianSanctuaryList = new();
@@ -446,6 +456,10 @@ namespace StageAesthetic.Config
                 SALogger.LogWarning("Distant Roost Alt list empty - adding vanilla...");
                 distantRoostAltList.Add("Vanilla");
             }
+
+            if (ShatteredAbodesVanilla.Value) shatteredAbodesList.Add("Vanilla");
+            if (ShatteredAbodesSunny.Value) shatteredAbodesList.Add("Verdant");
+            if (ShatteredAbodesAbandoned.Value) shatteredAbodesList.Add("Abandoned");
 
             if (SiphonedForestVanilla.Value) siphonedForestList.Add("Vanilla");
             if (SiphonedForestNight.Value) siphonedForestList.Add("Night");

--- a/SA.Content/Config/Config.cs
+++ b/SA.Content/Config/Config.cs
@@ -67,6 +67,17 @@ namespace StageAesthetic.Config
         public static ConfigEntry<bool> ShatteredAbodesSunny { get; set; }
         public static ConfigEntry<bool> ShatteredAbodesAbandoned { get; set; }
 
+        // Reformed Altar
+        public static ConfigEntry<bool> ReformedAltarVanilla { get; set; }
+        public static ConfigEntry<bool> ReformedAltarVerdant { get; set; }
+        public static ConfigEntry<bool> ReformedAltarHelminth { get; set; }
+
+        // Treeborn Colony
+        public static ConfigEntry<bool> TreebornColonyVanilla { get; set; }
+        public static ConfigEntry<bool> TreebornColonyOvercast { get; set; }
+        public static ConfigEntry<bool> TreebornColonySunny { get; set; }
+        public static ConfigEntry<bool> TreebornColonyNight { get; set; }
+
         // Aqueduct
         public static ConfigEntry<bool> AbandonedAqueductVanilla { get; set; }
 
@@ -224,6 +235,15 @@ namespace StageAesthetic.Config
             ShatteredAbodesVanilla = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Vanilla)?", true, "Disabling removes vanilla from getting picked");
             ShatteredAbodesSunny = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Verdant)?", true, "Sunny and bright green.");
             ShatteredAbodesAbandoned = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Abandoned)?", true, "Scorching Desert.");
+
+            ReformedAltarVanilla = SAConfig.Bind("Stages : Reformed Altar", "Enable Reformed Altar (Vanilla)?", true, "Disabling removes vanilla from getting picked");
+            ReformedAltarVerdant = SAConfig.Bind("Stages : Reformed Altar", "Enable Reformed Altar (Verdant)?", true, "Sunny and bright green.");
+            ReformedAltarHelminth = SAConfig.Bind("Stages : Reformed Altar", "Enable Reformed Altar (Helminth)?", true, "Dark and red.");
+
+            TreebornColonyVanilla = SAConfig.Bind("Stages : Treeborn Colony", "Enable Treeborn Colony (Vanilla)?", true, "Disabling removes vanilla from getting picked");
+            TreebornColonyOvercast = SAConfig.Bind("Stages : Treeborn Colony", "Enable Treeborn Colony (Overcast)?", true, "Foggy storm.");
+            TreebornColonySunny = SAConfig.Bind("Stages : Treeborn Colony", "Enable Treeborn Colony (Sunny)?", true, "Sunny, blue sky, and changes sun's angle.");
+            TreebornColonyNight = SAConfig.Bind("Stages : Treeborn Colony", "Enable Treeborn Colony (Night)?", true, "Dark and blue with a starry sky.");
 
             SiphonedForestVanilla = SAConfig.Bind("Stages : Siphoned Forest", "Enable Siphoned Forest (Vanilla)?", true, "Disabling removes vanilla from getting picked");
             SiphonedForestNight = SAConfig.Bind("Stages : Siphoned Forest", "Enable Siphoned Forest (Night)?", true, "Blue and dark.");
@@ -407,6 +427,9 @@ namespace StageAesthetic.Config
             titanicPlainsList = new();
             shatteredAbodesList = new();
 
+            reformedAltarList = new();
+            treebornColonyList = new();
+
             abandonedAqueductList = new();
             aphelianSanctuaryList = new();
             dryBasinList = new();
@@ -461,6 +484,15 @@ namespace StageAesthetic.Config
             if (ShatteredAbodesSunny.Value) shatteredAbodesList.Add("Verdant");
             if (ShatteredAbodesAbandoned.Value) shatteredAbodesList.Add("Abandoned");
 
+            if (ReformedAltarVanilla.Value) reformedAltarList.Add("Vanilla");
+            if (ReformedAltarVerdant.Value) reformedAltarList.Add("Verdant");
+            if (ReformedAltarHelminth.Value) reformedAltarList.Add("Helminth");
+
+            if (TreebornColonyVanilla.Value) treebornColonyList.Add("Vanilla");
+            if (TreebornColonyOvercast.Value) treebornColonyList.Add("Overcast");
+            if (TreebornColonySunny.Value) treebornColonyList.Add("Sunny");
+            if (TreebornColonyNight.Value) treebornColonyList.Add("Night");
+
             if (SiphonedForestVanilla.Value) siphonedForestList.Add("Vanilla");
             if (SiphonedForestNight.Value) siphonedForestList.Add("Night");
             if (SiphonedForestMorning.Value) siphonedForestList.Add("Morning");
@@ -484,8 +516,6 @@ namespace StageAesthetic.Config
                 SALogger.LogWarning("Titanic Plains list empty - adding vanilla...");
                 titanicPlainsList.Add("Vanilla");
             }
-
-            //
 
             if (AbandonedAqueductVanilla.Value) abandonedAqueductList.Add("Vanilla");
             if (AbandonedAqueductDawn.Value) abandonedAqueductList.Add("Dawn");

--- a/SA.Content/Config/Config.cs
+++ b/SA.Content/Config/Config.cs
@@ -67,6 +67,11 @@ namespace StageAesthetic.Config
         public static ConfigEntry<bool> ShatteredAbodesSunny { get; set; }
         public static ConfigEntry<bool> ShatteredAbodesAbandoned { get; set; }
 
+        // Verdant
+        public static ConfigEntry<bool> VerdantFallsVanilla { get; set; }
+        public static ConfigEntry<bool> VerdantFallsSunny { get; set; }
+        public static ConfigEntry<bool> VerdantFallsPurple { get; set; }
+
         // Reformed Altar
         public static ConfigEntry<bool> ReformedAltarVanilla { get; set; }
         public static ConfigEntry<bool> ReformedAltarVerdant { get; set; }
@@ -240,6 +245,10 @@ namespace StageAesthetic.Config
             ShatteredAbodesVanilla = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Vanilla)?", true, "Disabling removes vanilla from getting picked");
             ShatteredAbodesSunny = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Verdant)?", true, "Sunny and bright green.");
             ShatteredAbodesAbandoned = SAConfig.Bind("Stages : Shattered Abodes", "Enable Shattered Abodes (Abandoned)?", true, "Scorching Desert.");
+
+            VerdantFallsVanilla = SAConfig.Bind("Stages : Verdant Falls", "Enable Verdant Falls (Vanilla)?", true, "Disabling removes vanilla from getting picked");
+            VerdantFallsSunny = SAConfig.Bind("Stages : Verdant Falls", "Enable Verdant Falls (Sunny)?", true, "Sunny and bright.");
+            VerdantFallsPurple = SAConfig.Bind("Stages : Verdant Falls", "Enable Verdant Falls (Purple)?", true, "Purple sky with snow.");
 
             ReformedAltarVanilla = SAConfig.Bind("Stages : Reformed Altar", "Enable Reformed Altar (Vanilla)?", true, "Disabling removes vanilla from getting picked");
             ReformedAltarVerdant = SAConfig.Bind("Stages : Reformed Altar", "Enable Reformed Altar (Verdant)?", true, "Sunny and bright green.");
@@ -435,6 +444,7 @@ namespace StageAesthetic.Config
             siphonedForestList = new();
             titanicPlainsList = new();
             shatteredAbodesList = new();
+            verdantFallsList = new();
 
             reformedAltarList = new();
             treebornColonyList = new();
@@ -493,6 +503,10 @@ namespace StageAesthetic.Config
             if (ShatteredAbodesVanilla.Value) shatteredAbodesList.Add("Vanilla");
             if (ShatteredAbodesSunny.Value) shatteredAbodesList.Add("Verdant");
             if (ShatteredAbodesAbandoned.Value) shatteredAbodesList.Add("Abandoned");
+
+            if (VerdantFallsVanilla.Value) verdantFallsList.Add("Vanilla");
+            if (VerdantFallsSunny.Value) verdantFallsList.Add("Sunny");
+            if (VerdantFallsPurple.Value) verdantFallsList.Add("Purple");
 
             if (ReformedAltarVanilla.Value) reformedAltarList.Add("Vanilla");
             if (ReformedAltarVerdant.Value) reformedAltarList.Add("Verdant");

--- a/SA.Content/Config/Config.cs
+++ b/SA.Content/Config/Config.cs
@@ -179,6 +179,11 @@ namespace StageAesthetic.Config
         public static ConfigEntry<bool> SkyMeadowTitanic { get; set; }
         public static ConfigEntry<bool> SkyMeadowAbandoned { get; set; }
 
+        // Helminth Hatchery
+        public static ConfigEntry<bool> HelminthHatcheryVanilla { get; set; }
+        public static ConfigEntry<bool> HelminthHatcheryVanillaChanges { get; set; }
+        public static ConfigEntry<bool> HelminthHatcheryLunar { get; set; }
+
         // Satellite
         public static ConfigEntry<bool> SlumberingSatelliteVanilla { get; set; }
 
@@ -341,6 +346,10 @@ namespace StageAesthetic.Config
 
             SkyMeadowChanges = SAConfig.Bind("Stages ::::: Sky Meadow", "Alter Sky Meadow (Vanilla)?", true, "Makes the sun a slightly more intense yellow-orange.");
 
+            HelminthHatcheryVanilla = SAConfig.Bind("Stages ::::: Helminth Hatchery", "Enable Helminth Hatchery (Vanilla)?", true, "Disabling removes vanilla from getting picked.");
+            HelminthHatcheryVanillaChanges = SAConfig.Bind("Stages ::::: Helminth Hatchery", "Alter Helminth Hatchery (Vanilla)?", true, "Removes smoke from screen and brightens up the map.");
+            HelminthHatcheryLunar = SAConfig.Bind("Stages ::::: Helminth Hatchery", "Enable Helminth Hatchery (Lunar)?", true, "Bleu and ashy terrain.");
+
             SlumberingSatelliteVanilla = SAConfig.Bind("Stages ::::: Slumbering Satellite", "Enable Slumbering Satellite (Vanilla)?", true, "Disabling removes vanilla from getting picked");
             SlumberingSatelliteMorning = SAConfig.Bind("Stages ::::: Slumbering Satellite", "Enable Slumbering Satellite (Morning)?", true, "Blue and yellow.");
             SlumberingSatelliteOvercast = SAConfig.Bind("Stages ::::: Slumbering Satellite", "Enable Slumbering Satellite (Overcast)?", true, "Rainy with more fog.");
@@ -446,6 +455,7 @@ namespace StageAesthetic.Config
 
             skyMeadowList = new();
             slumberingSatelliteList = new();
+            helminthHatcheryList = new();
 
             commencementList = new();
             voidLocusList = new();
@@ -642,6 +652,9 @@ namespace StageAesthetic.Config
             }
 
             //
+
+            if (HelminthHatcheryVanilla.Value) helminthHatcheryList.Add("Vanilla");
+            if (HelminthHatcheryLunar.Value) helminthHatcheryList.Add("Lunar");
 
             if (SkyMeadowVanilla.Value) skyMeadowList.Add("Vanilla");
             if (SkyMeadowNight.Value) skyMeadowList.Add("Night");

--- a/SA.Content/Main.cs
+++ b/SA.Content/Main.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using System.Reflection;
 using System.Collections.Generic;
 using UnityEngine.AddressableAssets;
+using R2API;
 
 namespace StageAesthetic
 {
@@ -58,12 +59,14 @@ namespace StageAesthetic
         public static Texture2D siphonedDesolateNormal;
         public static Texture2D siphonedDesolateSide;
         public static Texture2D siphonedDesolateTop;
+        public static Material siphonedDesolateTreeRingMat;
         public static Material siphonedDesolateTerrainMat;
         public static Material siphonedDesolateDetailMat;
         public static Material siphonedDesolateDetailMat2;
         public static Material siphonedDesolateDetailMat3;
         public static Material siphonedDesolateDetailMat4;
         public static Material siphonedDesolateDetailMat5;
+        public static Material siphonedDesolateDetailMat6;
         public static Material siphonedDesolateWaterMat;
 
         public static Material aqueductSunderedTerrainMat;
@@ -160,13 +163,21 @@ namespace StageAesthetic
         public static Material meridianDetailMat3;
         public static Material meridianStormCloudMat;
 
+        public static Material verdantNightWaterMat;
+        public static Material verdantNightWaterfallMat;
+
+        public static Material helminthLavaMat;
+
         public static Material moonRedFlameMat;
         public static Material moonPurpleFlameMat;
 
-        public static bool ForgottenRelicsLoaded = false;
+        public static Material moonTerrainMat = Addressables.LoadAssetAsync<Material>("RoR2/Base/moon/matMoonTerrain.mat").WaitForCompletion();
+        public static Material moonDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/Base/moon/matMoonBoulder.mat").WaitForCompletion();
+        public static Material moonDetailMat2 = Addressables.LoadAssetAsync<Material>("RoR2/Base/moon/matMoonBridge.mat").WaitForCompletion();
+        public static Material moonDetailMat3 = Addressables.LoadAssetAsync<Material>("RoR2/Base/moon/matMoonBaseStandTriplanar.mat").WaitForCompletion();
+        public static Material blueFireMat = Addressables.LoadAssetAsync<Material>("RoR2/Base/Common/VFX/matFireStaticBlueLarge.mat").WaitForCompletion();
 
-        public static GameObject helminthFlower = Addressables.LoadAssetAsync<GameObject>("RoR2/DLC2/helminthroost/Assets/HRFireBlossom.prefab").WaitForCompletion();
-        public static GameObject helminthWeather = Addressables.LoadAssetAsync<GameObject>("RoR2/DLC2/helminthroost/Weather, Helminthroost.prefab").WaitForCompletion();
+        public static bool ForgottenRelicsLoaded = false;
 
         public void Awake()
         {
@@ -210,6 +221,11 @@ namespace StageAesthetic
             Texture2D tlCliffTex = Addressables.LoadAssetAsync<Texture2D>("RoR2/DLC2/lakes/Assets/texTLTerrainCliff.tga").WaitForCompletion();
             Texture2D tlDirtTex = Addressables.LoadAssetAsync<Texture2D>("RoR2/DLC2/lakes/Assets/texTLTerrainDirt.tga").WaitForCompletion();
             Texture2D rockNormal = Addressables.LoadAssetAsync<Texture2D>("RoR2/Base/Common/texNormalBumpyRock.jpg").WaitForCompletion();
+
+            verdantNightWaterMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakesnight/Assets/matTLSlowWaterNight.mat").WaitForCompletion();
+            verdantNightWaterfallMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakesnight/Assets/matTLSlowWaterFallsNight.mat").WaitForCompletion();
+
+            helminthLavaMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRLava.mat").WaitForCompletion();
 
             meridianTerrainMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/meridian/Assets/matPMTerrainDirt.mat").WaitForCompletion();
             meridianDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/meridian/Assets/matPMFloatingCrystal.mat").WaitForCompletion();
@@ -294,6 +310,9 @@ namespace StageAesthetic
             siphonedDesolateTerrainMat.SetTexture("_RedChannelSideTex", siphonedDesolateSide);
             siphonedDesolateTerrainMat.SetTexture("_RedChannelTopTex", siphonedDesolateTop);
 
+            siphonedDesolateTreeRingMat = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/DLC1/snowyforest/matSFTreering.mat").WaitForCompletion());
+            siphonedDesolateTreeRingMat.SetTexture("_SnowTex", siphonedDesolateTerrainMat.GetTexture("_GreenChannelTex"));
+
             siphonedDesolateTerrainMat.SetFloat("_GreenChannelBias", 1.87f);
             siphonedDesolateTerrainMat.SetFloat("_GreenChannelSpecularStrength", 0f);
             siphonedDesolateTerrainMat.SetFloat("_GreenChannelSpecularExponent", 20f);
@@ -325,7 +344,8 @@ namespace StageAesthetic
             siphonedDesolateDetailMat4.color = new Color32(255, 255, 255, 255);
             siphonedDesolateDetailMat5 = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/Captain/matCaptainSupplyDropEquipmentRestock.mat").WaitForCompletion());
             siphonedDesolateDetailMat5.color = new Color32(80, 162, 90, 255);
-
+            siphonedDesolateDetailMat6 = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/Captain/matCaptainSupplyDropEquipmentRestock.mat").WaitForCompletion());
+            siphonedDesolateDetailMat6.color = new Color32(80, 162, 90, 255);
             // Abandoned Aqueduct (Sundered)
 
             aqueductSunderedTerrainMat = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/rootjungle/matRJTerrain2.mat").WaitForCompletion());

--- a/SA.Content/Main.cs
+++ b/SA.Content/Main.cs
@@ -16,7 +16,7 @@ namespace StageAesthetic
         public const string PluginAuthor = "HIFU";
         public const string PluginName = "StageAesthetic";
 
-        public const string PluginVersion = "1.1.0";
+        public const string PluginVersion = "1.2.0";
 
         public static AssetBundle stageaesthetic;
         public static Shader cloudRemap = Addressables.LoadAssetAsync<Shader>("RoR2/Base/Shaders/HGCloudRemap.shader").WaitForCompletion();
@@ -47,6 +47,11 @@ namespace StageAesthetic
         public static Material plainsAbandonedDetailMat2;
         public static Material plainsAbandonedDetailMat3;
         public static Material plainsAbandonedWaterMat;
+
+        public static Material verdantTerrainMat;
+        public static Material verdantDetailMat;
+        public static Material verdantDetailMat2;
+        public static Material verdantDetailMat3;
 
         public static Texture2D siphonedDesolateNormal;
         public static Texture2D siphonedDesolateSide;
@@ -132,6 +137,11 @@ namespace StageAesthetic
         public static Material skyMeadowAbandonedDetailMat6;
         public static Material skyMeadowAbandonedWaterMat;
 
+        public static Material itSkyMeadowTerrainMat;
+        public static Material itSkyMeadowDetailMat;
+        public static Material itSkyMeadowDetailMat2;
+        public static Material itSkyMeadowDetailMat3;
+
         public static Material moonRedFlameMat;
         public static Material moonPurpleFlameMat;
 
@@ -170,6 +180,30 @@ namespace StageAesthetic
             moonPurpleFlameMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/voidoutro/matFireStaticVoidOutroEyePurple.mat").WaitForCompletion();
             // pre-caching in hopes of eliminating the null material issue
 
+            itSkyMeadowTerrainMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itskymeadow/matSMTerrainInfiniteTower.mat").WaitForCompletion();
+            itSkyMeadowDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itskymeadow/matSMRockInfiniteTower.mat").WaitForCompletion();
+            itSkyMeadowDetailMat2 = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itskymeadow/matTrimSheetMeadowRuinsProjectedInfiniteTower.mat").WaitForCompletion();
+            itSkyMeadowDetailMat3 = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itskymeadow/matSMSpikeBridgeInfinitetower.mat").WaitForCompletion();
+
+            // Shattered Abodes (Sunny)
+            Texture2D tlCliffTex = Addressables.LoadAssetAsync<Texture2D>("RoR2/DLC2/lakes/Assets/texTLTerrainCliff.tga").WaitForCompletion();
+            Texture2D tlDirtTex = Addressables.LoadAssetAsync<Texture2D>("RoR2/DLC2/lakes/Assets/texTLTerrainDirt.tga").WaitForCompletion();
+            Texture2D rockNormal = Addressables.LoadAssetAsync<Texture2D>("RoR2/Base/Common/texNormalBumpyRock.jpg").WaitForCompletion();
+            /*
+            overgrowthTerrainMat = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itancientloft/matAncientLoft_TempleProjectedInfiniteTower.mat").WaitForCompletion());
+            overgrowthTerrainMat.color = new Color(0.701f, 0.623f, 0.403f, 1);
+            overgrowthTerrainMat.SetTexture("_SplatmapTex", null);
+            // overgrowthTerrainMat.SetTexture("_NormalTex", rockNormal);
+            overgrowthTerrainMat.SetTexture("_RedChannelSideTex", tlCliffTex);
+            overgrowthTerrainMat.SetTexture("_RedChannelTopTex", tlDirtTex);
+            overgrowthDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itancientloft/matAncientLoft_BoulderInfiniteTower.mat").WaitForCompletion();
+            overgrowthDetailMat2 = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itancientloft/matAncientLoft_TempleProjectedInfiniteTower.mat").WaitForCompletion();
+            overgrowthDetailMat3 = Addressables.LoadAssetAsync<Material>("RoR2/Base/rootjungle/matRJTree.mat").WaitForCompletion();
+            */
+            verdantTerrainMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLTerrainStone.mat").WaitForCompletion();
+            verdantDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLRocks.mat").WaitForCompletion();
+            verdantDetailMat2 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLShip.mat").WaitForCompletion();
+            verdantDetailMat3 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLGVine.mat").WaitForCompletion();
             // Distant Roost (Void)
 
             distantRoostVoidTerrainMat = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/arena/matArenaTerrain.mat").WaitForCompletion());
@@ -395,21 +429,10 @@ namespace StageAesthetic
             if (BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("PlasmaCore.ForgottenRelics"))
                 ForgottenRelicsLoaded = true;
 
-            On.RoR2.RoR2Application.Start += RoR2Application_Start;
 
             SwapVariants.Initialize();
 
             // SwapVariants.SALogger.LogError("Forgotten Relics Loaded:" + ForgottenRelicsLoaded);
-        }
-
-        private void RoR2Application_Start(On.RoR2.RoR2Application.orig_Start orig, RoR2.RoR2Application self)
-        {
-            orig(self);
-            var path = typeof(Main).Assembly.Location.Replace("StageAesthetic.dll", "");
-            AkSoundEngine.AddBasePath(path);
-
-            AkSoundEngine.LoadBank("InitSA", out _);
-            AkSoundEngine.LoadBank("StageAesthetic", out _);
         }
     }
 }

--- a/SA.Content/Main.cs
+++ b/SA.Content/Main.cs
@@ -52,6 +52,8 @@ namespace StageAesthetic
         public static Material verdantDetailMat;
         public static Material verdantDetailMat2;
         public static Material verdantDetailMat3;
+        public static Material verdantGrassMat;
+        public static Material verdantBlueGrassMat;
 
         public static Texture2D siphonedDesolateNormal;
         public static Texture2D siphonedDesolateSide;
@@ -142,10 +144,29 @@ namespace StageAesthetic
         public static Material itSkyMeadowDetailMat2;
         public static Material itSkyMeadowDetailMat3;
 
+        public static Material reformedAltarTempleMat;
+
+        public static Material helminthTerrainMat;
+        public static Material helminthDetailMat;
+        public static Material helminthDetailMat2;
+        public static Material helminthDetailMat3;
+        public static Material helminthGrassMat;
+        public static Material helminthGrassMat2;
+        public static Material helminthObsidianMat;
+
+        public static Material meridianTerrainMat;
+        public static Material meridianDetailMat;
+        public static Material meridianDetailMat2;
+        public static Material meridianDetailMat3;
+        public static Material meridianStormCloudMat;
+
         public static Material moonRedFlameMat;
         public static Material moonPurpleFlameMat;
 
         public static bool ForgottenRelicsLoaded = false;
+
+        public static GameObject helminthFlower = Addressables.LoadAssetAsync<GameObject>("RoR2/DLC2/helminthroost/Assets/HRFireBlossom.prefab").WaitForCompletion();
+        public static GameObject helminthWeather = Addressables.LoadAssetAsync<GameObject>("RoR2/DLC2/helminthroost/Weather, Helminthroost.prefab").WaitForCompletion();
 
         public void Awake()
         {
@@ -189,6 +210,23 @@ namespace StageAesthetic
             Texture2D tlCliffTex = Addressables.LoadAssetAsync<Texture2D>("RoR2/DLC2/lakes/Assets/texTLTerrainCliff.tga").WaitForCompletion();
             Texture2D tlDirtTex = Addressables.LoadAssetAsync<Texture2D>("RoR2/DLC2/lakes/Assets/texTLTerrainDirt.tga").WaitForCompletion();
             Texture2D rockNormal = Addressables.LoadAssetAsync<Texture2D>("RoR2/Base/Common/texNormalBumpyRock.jpg").WaitForCompletion();
+
+            meridianTerrainMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/meridian/Assets/matPMTerrainDirt.mat").WaitForCompletion();
+            meridianDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/meridian/Assets/matPMFloatingCrystal.mat").WaitForCompletion();
+            meridianDetailMat2 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/meridian/Assets/matPMTerrainPlayZone.mat").WaitForCompletion();
+            meridianDetailMat3 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/meridian/Assets/matPMShrineStoneBell.mat").WaitForCompletion();
+            meridianStormCloudMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/meridian/Assets/matPMStormCloud.mat").WaitForCompletion();
+
+            reformedAltarTempleMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lemuriantemple/Assets/matLTFloor.mat").WaitForCompletion();
+
+            helminthTerrainMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRTerrain.mat").WaitForCompletion();
+            //helminthTerrainMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRTerrainOuter.mat").WaitForCompletion();
+            helminthDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRRocks.mat").WaitForCompletion();
+            helminthDetailMat2 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRWalls.mat").WaitForCompletion();
+            helminthDetailMat3 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRTerrainLava.mat").WaitForCompletion();
+            helminthGrassMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRFireGrass.mat").WaitForCompletion();
+            helminthObsidianMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRObsidian.mat").WaitForCompletion();
+            // helminthGrassMat2 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/helminthroost/Assets/matHRFireBlossom.mat").WaitForCompletion();
             /*
             overgrowthTerrainMat = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/DLC1/itancientloft/matAncientLoft_TempleProjectedInfiniteTower.mat").WaitForCompletion());
             overgrowthTerrainMat.color = new Color(0.701f, 0.623f, 0.403f, 1);
@@ -204,6 +242,8 @@ namespace StageAesthetic
             verdantDetailMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLRocks.mat").WaitForCompletion();
             verdantDetailMat2 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLShip.mat").WaitForCompletion();
             verdantDetailMat3 = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLGVine.mat").WaitForCompletion();
+            verdantGrassMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/MatTLGrassSparseGreen.mat").WaitForCompletion();
+            verdantBlueGrassMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC2/lakes/Assets/matTLGrassSparseBlue.mat").WaitForCompletion();
             // Distant Roost (Void)
 
             distantRoostVoidTerrainMat = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/arena/matArenaTerrain.mat").WaitForCompletion());

--- a/SA.Content/Skybox.cs
+++ b/SA.Content/Skybox.cs
@@ -9,10 +9,10 @@ namespace StageAesthetic
 {
     public class Skybox
     {
-        private static readonly PostProcessProfile ppPlains = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/ppSceneGolemplainsFoggy.asset").WaitForCompletion();
-        private static readonly PostProcessProfile ppPlainsRoost = Object.Instantiate(Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/ppSceneGolemplainsFoggy.asset").WaitForCompletion());
-        private static readonly PostProcessProfile ppSunset = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/ppSceneWispGraveyard.asset").WaitForCompletion();
-        private static readonly PostProcessProfile ppSick = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/ppSceneMysterySpace.asset").WaitForCompletion();
+        private static readonly PostProcessProfile ppPlains = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplainsFoggy.asset").WaitForCompletion();
+        private static readonly PostProcessProfile ppPlainsRoost = Object.Instantiate(Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplainsFoggy.asset").WaitForCompletion());
+        private static readonly PostProcessProfile ppSunset = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneWispGraveyard.asset").WaitForCompletion();
+        private static readonly PostProcessProfile ppSick = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneMysterySpace.asset").WaitForCompletion();
         private static readonly Material sunMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/ancientloft/matAncientLoft_Sun.mat").WaitForCompletion();
         private static readonly Material sunsetSkyboxMat = Addressables.LoadAssetAsync<Material>("RoR2/Base/bazaar/matSkybox4.mat").WaitForCompletion();
         private static readonly Material spaceSkyboxMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/sulfurpools/matSkyboxSP.mat").WaitForCompletion();
@@ -56,7 +56,17 @@ namespace StageAesthetic
             if (SceneManager.GetActiveScene().name == "snowyforest" || SceneManager.GetActiveScene().name == "foggyswamp" || SceneManager.GetActiveScene().name == "frozenwall" || SceneManager.GetActiveScene().name == "skymeadow")
                 GameObject.Destroy(skybox.transform.GetChild(0).GetComponent<PostProcessVolume>());
             else
-                skybox.transform.GetChild(0).GetComponent<PostProcessVolume>().profile = ppPlains;
+                skybox.transform.GetChild(0).GetComponent<PostProcessVolume>().profile = ppPlainsRoost;
+
+            RampFog fog = ppPlainsRoost.GetSetting<RampFog>();
+            fog.fogColorStart.value = new Color32(127, 127, 153, 25);
+            fog.fogColorMid.value = new Color32(0, 106, 145, 150);
+            fog.fogColorEnd.value = new Color32(0, 115, 119, 255);
+            fog.fogZero.value = -0.01f;
+            fog.fogOne.value = 0.15f;
+            fog.fogPower.value = 2f;
+            fog.skyboxStrength.value = 0.1f;
+
             SetAmbientLight ambLight = skybox.transform.GetChild(0).GetComponent<SetAmbientLight>();
             ambLight.skyboxMaterial = spaceSkyboxMat;
             ambLight.ambientIntensity = 1f;

--- a/SA.Content/Skybox.cs
+++ b/SA.Content/Skybox.cs
@@ -10,6 +10,7 @@ namespace StageAesthetic
     public class Skybox
     {
         private static readonly PostProcessProfile ppPlains = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplainsFoggy.asset").WaitForCompletion();
+        private static readonly PostProcessProfile ppScorched = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneWispGraveyard.asset").WaitForCompletion();
         private static readonly PostProcessProfile ppPlainsRoost = Object.Instantiate(Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplainsFoggy.asset").WaitForCompletion());
         private static readonly PostProcessProfile ppSunset = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneWispGraveyard.asset").WaitForCompletion();
         private static readonly PostProcessProfile ppSick = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneMysterySpace.asset").WaitForCompletion();
@@ -94,11 +95,7 @@ namespace StageAesthetic
             if (SceneManager.GetActiveScene().name != "ancientloft")
                 sunInstance = Object.Instantiate(sun, skybox.transform);
 
-            if (SceneManager.GetActiveScene().name != "goolake")
-            {
-                //skybox.transform.GetChild(1).GetComponent<Light>().color = new Color(1f, 0f, 0f);
-                GameObject.Destroy(skybox.transform.GetChild(0).GetComponent<PostProcessVolume>());
-            }
+            skybox.transform.GetChild(0).GetComponent<PostProcessVolume>().profile = ppScorched;
 
             if (SceneManager.GetActiveScene().name == "ancientloft")
                 skybox.transform.GetChild(1).GetComponent<Light>().color = new Color(0.75f, 0.25f, 0.25f);
@@ -169,10 +166,6 @@ namespace StageAesthetic
                     sunInstance.transform.rotation = Quaternion.Euler(0, 80, 0);
                     break;
             }
-            if (sceneName == "goolake")
-            {
-                skybox.transform.GetChild(0).GetComponent<PostProcessVolume>().profile = ppPlains;
-            }
 
             SetAmbientLight ambLight = skybox.transform.GetChild(0).GetComponent<SetAmbientLight>();
             ambLight.skyboxMaterial = sunsetSkyboxMat;
@@ -195,7 +188,7 @@ namespace StageAesthetic
 
             if (sceneName == "dampcavesimple")
             {
-                moonLight.intensity = 1.5f;
+                moonLight.intensity = 1.25f;
             }
             else if (sceneName == "moon2")
             {
@@ -203,10 +196,10 @@ namespace StageAesthetic
             }
             else
             {
-                moonLight.intensity = 1.25f;
+                moonLight.intensity = 1f;
             }
 
-            moonLight.shadowStrength = 0.25f;
+            moonLight.shadowStrength = 0.5f;
 
             newWeather.transform.GetChild(2).GetComponent<PostProcessVolume>().profile = ppSick;
 
@@ -219,15 +212,15 @@ namespace StageAesthetic
 
             if (sceneName == "blackbeach" || sceneName == "blackbeach2")
             {
-                ambLight.ambientIntensity = 1.25f;
+                ambLight.ambientIntensity = 1f;
             }
             else if (SceneManager.GetActiveScene().name != "ancientloft" && SceneManager.GetActiveScene().name != "foggyswamp")
             {
-                ambLight.ambientIntensity = 1f;
+                ambLight.ambientIntensity = 0.75f;
             }
             else
             {
-                ambLight.ambientIntensity = 0.75f;
+                ambLight.ambientIntensity = 0.5f;
             }
 
             if (sceneName == "frozenwall" || sceneName == "snowyforest" || sceneName == "moon2")

--- a/SA.Content/Skybox.cs
+++ b/SA.Content/Skybox.cs
@@ -14,14 +14,14 @@ namespace StageAesthetic
         private static readonly PostProcessProfile ppPlainsRoost = Object.Instantiate(Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplainsFoggy.asset").WaitForCompletion());
         private static readonly PostProcessProfile ppSunset = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneWispGraveyard.asset").WaitForCompletion();
         private static readonly PostProcessProfile ppSick = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneMysterySpace.asset").WaitForCompletion();
-        private static readonly Material sunMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/ancientloft/matAncientLoft_Sun.mat").WaitForCompletion();
+        public static readonly Material sunMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/ancientloft/matAncientLoft_Sun.mat").WaitForCompletion();
         private static readonly Material sunsetSkyboxMat = Addressables.LoadAssetAsync<Material>("RoR2/Base/bazaar/matSkybox4.mat").WaitForCompletion();
         private static readonly Material spaceSkyboxMat = Addressables.LoadAssetAsync<Material>("RoR2/DLC1/sulfurpools/matSkyboxSP.mat").WaitForCompletion();
         private static readonly Material spaceStarsMat2 = Addressables.LoadAssetAsync<Material>("RoR2/Base/eclipseworld/matEclipseStarsSpheres.mat").WaitForCompletion();
         private static readonly GameObject eclipseSkybox = PrefabAPI.InstantiateClone(Addressables.LoadAssetAsync<GameObject>("RoR2/Base/eclipseworld/Weather, Eclipse.prefab").WaitForCompletion(), "SAEclipseSkybox", false);
         private static readonly GameObject planetariumSkybox = PrefabAPI.InstantiateClone(Addressables.LoadAssetAsync<GameObject>("RoR2/DLC1/voidraid/Weather, Void Raid Starry Night Variant.prefab").WaitForCompletion(), "SADaySkybox", false);
         private static readonly GameObject voidStageSkybox = PrefabAPI.InstantiateClone(Addressables.LoadAssetAsync<GameObject>("RoR2/DLC1/voidstage/Weather, Void Stage.prefab").WaitForCompletion(), "SAVoidSkybox", false);
-        private static readonly GameObject sun = PrefabAPI.InstantiateClone(Addressables.LoadAssetAsync<GameObject>("RoR2/DLC1/ancientloft/mdlAncientLoft_Terrain.fbx").WaitForCompletion().transform.GetChild(5).GetChild(0).gameObject, "SASun", false);
+        public static readonly GameObject sun = PrefabAPI.InstantiateClone(Addressables.LoadAssetAsync<GameObject>("RoR2/DLC1/ancientloft/mdlAncientLoft_Terrain.fbx").WaitForCompletion().transform.GetChild(5).GetChild(0).gameObject, "SASun", false);
 
         public static void SunnyDistantRoostSky()
         {
@@ -212,15 +212,11 @@ namespace StageAesthetic
 
             if (sceneName == "blackbeach" || sceneName == "blackbeach2")
             {
-                ambLight.ambientIntensity = 1f;
-            }
-            else if (SceneManager.GetActiveScene().name != "ancientloft" && SceneManager.GetActiveScene().name != "foggyswamp")
-            {
-                ambLight.ambientIntensity = 0.75f;
+                ambLight.ambientIntensity = 1.25f;
             }
             else
             {
-                ambLight.ambientIntensity = 0.5f;
+                ambLight.ambientIntensity = 1f;
             }
 
             if (sceneName == "frozenwall" || sceneName == "snowyforest" || sceneName == "moon2")

--- a/SA.Content/Skybox.cs
+++ b/SA.Content/Skybox.cs
@@ -9,7 +9,7 @@ namespace StageAesthetic
 {
     public class Skybox
     {
-        private static readonly PostProcessProfile ppPlains = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplainsFoggy.asset").WaitForCompletion();
+        private static readonly PostProcessProfile ppHelminth = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/DLC2/helminthroost/ppSceneHelminth.asset").WaitForCompletion();
         private static readonly PostProcessProfile ppScorched = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneWispGraveyard.asset").WaitForCompletion();
         private static readonly PostProcessProfile ppPlainsRoost = Object.Instantiate(Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplainsFoggy.asset").WaitForCompletion());
         private static readonly PostProcessProfile ppSunset = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneWispGraveyard.asset").WaitForCompletion();
@@ -26,15 +26,18 @@ namespace StageAesthetic
         public static void SunnyDistantRoostSky()
         {
             GameObject skybox = Object.Instantiate(planetariumSkybox, Vector3.zero, Quaternion.identity);
-            skybox.transform.GetChild(0).GetComponent<PostProcessVolume>().profile = ppPlainsRoost;
+            PostProcessProfile ppProfile = Object.Instantiate(ppPlainsRoost);
+            RampFog fog = ppProfile.GetSetting<RampFog>();
+            fog.fogColorStart.value = new Color32(53, 66, 82, 18);
+            fog.fogColorMid.value = new Color32(103, 67, 64, 154);
+            fog.fogColorEnd.value = new Color32(146, 176, 255, 255);
+            fog.fogOne.value = 0.2f;
+            fog.fogZero.value = -0.05f;
+            skybox.transform.GetChild(0).GetComponent<PostProcessVolume>().profile = ppProfile;
             SetAmbientLight ambLight = skybox.transform.GetChild(0).GetComponent<SetAmbientLight>();
             ambLight.skyboxMaterial = spaceSkyboxMat;
-            ambLight.ambientIntensity = 1f;
+            ambLight.ambientIntensity = 0.75f;
             ambLight.ApplyLighting();
-
-            var pp = skybox.transform.GetChild(0).GetComponent<PostProcessVolume>().profile.GetSetting<RampFog>();
-            pp.fogColorEnd.value = new Color32(125, 118, 108, 178);
-            pp.skyboxStrength.value = 0f;
 
             skybox.transform.GetChild(1).gameObject.SetActive(false);
             skybox.transform.GetChild(4).GetChild(0).GetChild(2).gameObject.SetActive(false);

--- a/SA.Content/Skybox.cs
+++ b/SA.Content/Skybox.cs
@@ -244,6 +244,10 @@ namespace StageAesthetic
             GameObject skybox = Object.Instantiate(voidStageSkybox, Vector3.zero, Quaternion.identity);
             switch (sceneName)
             {
+                case "lakes":
+                    skybox.transform.eulerAngles = new Vector3(45, 180, 180);
+                    break;
+
                 case "blackbeach":
                     skybox.transform.eulerAngles = new Vector3(30, 0, 220);
                     break;

--- a/SA.Content/StageAesthetic.csproj
+++ b/SA.Content/StageAesthetic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -31,38 +31,21 @@
     </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-    <PackageReference Include="RiskOfRain2.GameLibs" Version="1.2.4-r.0" />
-    <PackageReference Include="UnityEngine.Modules" Version="2019.4.26" />
-	<PackageReference Include="R2API.Networking" Version="1.0.2" />
-	  <PackageReference Include="R2API.Core" Version="5.0.6" />
-	<PackageReference Include="R2API.Prefab" Version="1.0.1" />
-	    <PackageReference Include="MMHOOK.RoR2" Version="2022.4.19">
-      <NoWarn>NU1701</NoWarn>
-    </PackageReference>
+    <PackageReference Include="BepInEx.Core" Version="5.*" />
+    <PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.2-r.1" NoWarn="NU5104" />
+    <PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
+    <PackageReference Include="MMHOOK.RoR2" Version="2024.9.5" NoWarn="NU1701" />
+    <PackageReference Include="R2API.Core" Version="5.1.1" />
+    <PackageReference Include="R2API.Prefab" Version="1.0.4" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="FHCSharp">
-      <HintPath>..\..\..\..\..\FHCSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="KinematicCharacterController">
-      <HintPath>libs\KinematicCharacterController.dll</HintPath>
-    </Reference>
-    <Reference Include="MMHOOK_RoR2">
-      <HintPath>libs\MMHOOK_RoR2.dll</HintPath>
-    </Reference>
-    <Reference Include="RiskOfOptions">
-      <HintPath>..\..\..\..\..\RiskOfOptions.dll</HintPath>
-    </Reference>
-    <Reference Include="RoR2">
-      <HintPath>..\..\libs\RoR2-nstrip.dll</HintPath>
+ <ItemGroup>
+   <Reference Include="RiskOfOptions">
+      <HintPath>libs\RiskOfOptions.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Unity.Postprocessing.Runtime">
-      <HintPath>P:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Unity.Postprocessing.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Wwise">
-      <HintPath>libs\Wwise.dll</HintPath>
+      <HintPath>libs\Unity.Postprocessing.Runtime.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/SA.Content/SwapVariants.cs
+++ b/SA.Content/SwapVariants.cs
@@ -91,10 +91,8 @@ namespace StageAesthetic
         {
             if (!rain)
             {
-                Debug.LogWarning("Loading rain");
                 rain = Main.stageaesthetic.LoadAsset<GameObject>("Stage Aesthetic Rain.prefab");
                 rain.transform.eulerAngles = new Vector3(90, 0, 0);
-                Debug.LogWarning(rain);
             }
 
             if (!snow)
@@ -360,6 +358,80 @@ namespace StageAesthetic
 
                         #endregion TitanicPlainsAndAlt
 
+                        break;
+
+                    case "habitat":
+
+                        #region TreebornColony
+                        int treebornColonyCounter = rng.RangeInt(0, treebornColonyList.Count);
+
+                        if (treebornColonyList.Count > 1 && treebornColonyCounter == treebornColonyVariant)
+                            treebornColonyCounter = (treebornColonyCounter + 1) % treebornColonyList.Count;
+
+                        string[] treebornColonyArray = treebornColonyList.ToArray();
+                        string selectedtreebornColonyVariant = treebornColonyArray[treebornColonyCounter];
+
+                        if (selectedtreebornColonyVariant == "Vanilla")
+                        {
+                            currentVariantName = "Vanilla";
+                        }
+                        else
+                            switch (selectedtreebornColonyVariant)
+                            {
+                                case "Sunny":
+                                    SetAmbientLight amb = volume.GetComponent<SetAmbientLight>();
+                                    amb.ambientSkyColor = new Color(0.88078f, 0.8431f, 0.5373f, 1);
+                                    amb.ApplyLighting();
+                                    TreebornColony.Sunny(rampFog);
+                                    break;
+                                case "Overcast":
+                                    SetAmbientLight amb2 = volume.GetComponent<SetAmbientLight>();
+                                    amb2.ambientSkyColor = new Color(0.5373f, 0.6354f, 0.6431f, 1);
+                                    amb2.ambientIntensity = 0.61f;
+                                    amb2.ApplyLighting();
+                                    TreebornColony.Meridian(rampFog);
+                                    break;
+                                case "Night":
+                                    TreebornColony.Night();
+                                    break;
+                            }
+
+                        currentVariantName = selectedtreebornColonyVariant;
+                        reformedAltarVariant = treebornColonyCounter;
+
+                        #endregion TreebornColony
+                        break;
+
+                    case "lemuriantemple":
+
+                        #region ReformedAltar
+                        int reformedAltarCounter = rng.RangeInt(0, reformedAltarList.Count);
+
+                        if (reformedAltarList.Count > 1 && reformedAltarCounter == reformedAltarVariant)
+                            reformedAltarCounter = (reformedAltarCounter + 1) % reformedAltarList.Count;
+
+                        string[] reformedAltarArray = reformedAltarList.ToArray();
+                        string selectedReformedAltarVariant = reformedAltarArray[reformedAltarCounter];
+
+                        if (selectedReformedAltarVariant == "Vanilla")
+                        {
+                            currentVariantName = "Vanilla";
+                        }
+                        else
+                            switch (selectedReformedAltarVariant)
+                            {
+                                case "Verdant":
+                                    ReformedAltar.Verdant(rampFog);
+                                    break;
+                                case "Helminth":
+                                    ReformedAltar.Helminth(rampFog);
+                                    break;
+                            }
+
+                        currentVariantName = selectedReformedAltarVariant;
+                        reformedAltarVariant = reformedAltarCounter;
+
+                        #endregion ReformedAltar
                         break;
 
                     case "village":
@@ -1034,6 +1106,9 @@ namespace StageAesthetic
         public static int titanicPlainsAltVariant = -1;
         public static int shatteredAbodesVariant = -1;
 
+        public static int reformedAltarVariant = -1;
+        public static int treebornColonyVariant = -1;
+
         public static int abandonedAqueductVariant = -1;
         public static int aphelianSanctuaryVariant = -1;
         public static int dryBasinVariant = -1;
@@ -1072,6 +1147,9 @@ namespace StageAesthetic
         public static List<string> siphonedForestList = new();
         public static List<string> titanicPlainsList = new();
         public static List<string> shatteredAbodesList = new();
+
+        public static List<string> reformedAltarList = new();
+        public static List<string> treebornColonyList = new();
 
         public static List<string> abandonedAqueductList = new();
         public static List<string> aphelianSanctuaryList = new();

--- a/SA.Content/SwapVariants.cs
+++ b/SA.Content/SwapVariants.cs
@@ -527,6 +527,16 @@ namespace StageAesthetic
                         string selectedAphelianSanctuaryVariant = aphelianSanctuaryArray[aphelianSanctuaryCounter];
                         if (selectedAphelianSanctuaryVariant == "Vanilla")
                         {
+                            GameObject sun = GameObject.Find("AL_Sun");
+                            if (sun)
+                            {
+                                sun.SetActive(false);
+                                GameObject newSun = GameObject.Instantiate(Skybox.sun, sun.transform.parent);
+                                newSun.transform.localPosition = new Vector3(-897.0126f, 350f, 209.9904f);
+                                newSun.transform.eulerAngles = new Vector3(275f, 90f, 90f);
+                                newSun.GetComponent<MeshRenderer>().sharedMaterial = Skybox.sunMat;
+                            }
+
                             currentVariantName = "Vanilla";
                         }
                         else
@@ -541,6 +551,16 @@ namespace StageAesthetic
                                     break;
 
                                 case "Sunset":
+                                    GameObject sun = GameObject.Find("AL_Sun");
+                                    if (sun)
+                                    {
+                                        sun.SetActive(false);
+                                        GameObject newSun = GameObject.Instantiate(Skybox.sun, sun.transform.parent);
+                                        newSun.transform.localPosition = new Vector3(-897.0126f, 350f, 209.9904f);
+                                        newSun.transform.eulerAngles = new Vector3(275f, 90f, 90f);
+                                        newSun.GetComponent<MeshRenderer>().sharedMaterial = Skybox.sunMat;
+                                    }
+
                                     AphelianSanctuary.Sunset(rampFog, colorGrading);
                                     break;
 

--- a/SA.Content/SwapVariants.cs
+++ b/SA.Content/SwapVariants.cs
@@ -433,7 +433,37 @@ namespace StageAesthetic
 
                         #endregion ReformedAltar
                         break;
+                    case "lakes":
 
+                        #region VerdantFalls
+                        int verdantFallsCounter = rng.RangeInt(0, verdantFallsList.Count);
+
+                        if (verdantFallsList.Count > 1 && verdantFallsCounter == verdantFallsVariant)
+                            verdantFallsCounter = (verdantFallsCounter + 1) % verdantFallsList.Count;
+
+                        string[] verdantFallsArray = verdantFallsList.ToArray();
+                        string selectedverdantFallsVariant = verdantFallsArray[verdantFallsCounter];
+
+                        if (selectedverdantFallsVariant == "Vanilla")
+                        {
+                            currentVariantName = "Vanilla";
+                        }
+                        else
+                            switch (selectedverdantFallsVariant)
+                            {
+                                case "Sunny":
+                                    VerdantFalls.Sunny(rampFog);
+                                    break;
+                                case "Purple":
+                                    VerdantFalls.Purple(rampFog);
+                                    break;
+                            }
+
+                        currentVariantName = selectedverdantFallsVariant;
+                        shatteredAbodesVariant = verdantFallsCounter;
+
+                        #endregion VerdantFalls
+                        break;
                     case "village":
 
                         #region ShatteredAbodes
@@ -1157,6 +1187,7 @@ namespace StageAesthetic
         public static int titanicPlainsVariant = -1;
         public static int titanicPlainsAltVariant = -1;
         public static int shatteredAbodesVariant = -1;
+        public static int verdantFallsVariant = -1;
 
         public static int reformedAltarVariant = -1;
         public static int treebornColonyVariant = -1;
@@ -1200,6 +1231,7 @@ namespace StageAesthetic
         public static List<string> siphonedForestList = new();
         public static List<string> titanicPlainsList = new();
         public static List<string> shatteredAbodesList = new();
+        public static List<string> verdantFallsList = new();
 
         public static List<string> reformedAltarList = new();
         public static List<string> treebornColonyList = new();

--- a/SA.Content/SwapVariants.cs
+++ b/SA.Content/SwapVariants.cs
@@ -963,6 +963,38 @@ namespace StageAesthetic
 
                         break;
 
+                    case "helminthroost":
+
+                        #region HelminthHatchery
+
+                        int helminthHatcheryCounter = rng.RangeInt(0, helminthHatcheryList.Count);
+
+                        if (helminthHatcheryList.Count > 1 && helminthHatcheryCounter == helminthHatcheryVariant)
+                            helminthHatcheryCounter = (helminthHatcheryCounter + 1) % helminthHatcheryList.Count;
+
+                        string[] helminthHatcheryArray = helminthHatcheryList.ToArray();
+                        string selectedHelminthHatcheryVariant = helminthHatcheryArray[helminthHatcheryCounter];
+                        if (selectedHelminthHatcheryVariant == "Vanilla")
+                        {
+                            if (HelminthHatcheryVanillaChanges.Value)
+                                HelminthHatchery.VanillaChanges(rampFog);
+                            currentVariantName = "Vanilla";
+                        }
+                        else
+                        {
+                            switch (selectedHelminthHatcheryVariant)
+                            {
+                                case "Lunar":
+                                    HelminthHatchery.Lunar(rampFog);
+                                    break;
+                            }
+                        }
+                        currentVariantName = selectedHelminthHatcheryVariant;
+                        helminthHatcheryVariant = helminthHatcheryCounter;
+
+                        #endregion HelminthHatchery
+
+                        break;
                     case "skymeadow":
 
                         #region SkyMeadow
@@ -1144,6 +1176,7 @@ namespace StageAesthetic
         public static int sunderedGroveVariant = -1;
 
         public static int skyMeadowVariant = -1;
+        public static int helminthHatcheryVariant = -1;
         public static int slumberingSatelliteVariant = -1;
 
         public static int commencementVariant = -1;
@@ -1186,6 +1219,7 @@ namespace StageAesthetic
         public static List<string> sunderedGroveList = new();
 
         public static List<string> skyMeadowList = new();
+        public static List<string> helminthHatcheryList = new();
         public static List<string> slumberingSatelliteList = new();
 
         public static List<string> commencementList = new();

--- a/SA.Content/SwapVariants.cs
+++ b/SA.Content/SwapVariants.cs
@@ -19,8 +19,8 @@ namespace StageAesthetic
     public class SwapVariants
     {
         public static string currentVariantName;
-        private static PostProcessProfile ppNostalgia = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/ppSceneGolemplains.asset").WaitForCompletion();
-        private static PostProcessProfile ppGoolake = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/ppSceneGoolake.asset").WaitForCompletion();
+        private static PostProcessProfile ppNostalgia = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGolemplains.asset").WaitForCompletion();
+        private static PostProcessProfile ppGoolake = Addressables.LoadAssetAsync<PostProcessProfile>("RoR2/Base/title/PostProcessing/ppSceneGoolake.asset").WaitForCompletion();
 
         public static void Initialize()
         {
@@ -76,15 +76,13 @@ namespace StageAesthetic
                     var menuWind = GameObject.Find("HOLDER: Title Background").transform.Find("FX").Find("WindZone").gameObject.GetComponent<WindZone>();
                     menuWind.windMain = 0.5f;
                     menuWind.windTurbulence = 1;
-                    StopSounds();
-                    PlaySound(SoundType.Wind);
                 }
             }
         }
 
         private static void SceneDirector_Start(On.RoR2.SceneDirector.orig_Start orig, SceneDirector self)
         {
-            StopSounds();
+
             ChangeProfile(SceneManager.GetActiveScene().name);
             orig(self);
         }
@@ -93,8 +91,10 @@ namespace StageAesthetic
         {
             if (!rain)
             {
+                Debug.LogWarning("Loading rain");
                 rain = Main.stageaesthetic.LoadAsset<GameObject>("Stage Aesthetic Rain.prefab");
                 rain.transform.eulerAngles = new Vector3(90, 0, 0);
+                Debug.LogWarning(rain);
             }
 
             if (!snow)
@@ -108,12 +108,13 @@ namespace StageAesthetic
                 sand = Main.stageaesthetic.LoadAsset<GameObject>("Stage Aesthetic Sand.prefab");
                 // sand.transform.eulerAngles = new Vector3(90, 0, 0);
             }
-
+            Debug.LogWarning("Past the prefab loading");
             ulong seed = Run.instance ? (ulong)(Run.instance.GetStartTimeUtc().Ticks ^ (Run.instance.stageClearCount << 16)) : 0;
             Xoroshiro128Plus rng = new(seed);
 
             var currentScene = SceneInfo.instance;
             if (currentScene) volume = currentScene.GetComponent<PostProcessVolume>();
+
             if (!volume || !volume.isActiveAndEnabled)
             {
                 GameObject alt = GameObject.Find("PP + Amb");
@@ -176,8 +177,6 @@ namespace StageAesthetic
                             if (DistantRoostChanges.Value)
                                 DistantRoost.Vanilla();
                             DistantRoost.VanillaFoliage();
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                             currentVariantName = "Vanilla";
                         }
                         else
@@ -185,19 +184,13 @@ namespace StageAesthetic
                             {
                                 case "Sunny":
                                     DistantRoost.Sunny(rampFog, sceneName, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Overcast":
                                     DistantRoost.Overcast(rampFog, sceneName);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Void":
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     GameObject cliff = GameObject.Find("mdlBBCliffLarge1 (6)");
                                     GameObject cliff2 = GameObject.Find("mdlBBCliffLarge1 (5)");
                                     if (cliff)
@@ -209,8 +202,6 @@ namespace StageAesthetic
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedDistantRoostVariant;
@@ -236,8 +227,6 @@ namespace StageAesthetic
                             if (DistantRoostChanges.Value)
                                 DistantRoost.Vanilla();
                             DistantRoost.VanillaFoliage();
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                             currentVariantName = "Vanilla";
                         }
                         else
@@ -245,32 +234,22 @@ namespace StageAesthetic
                             {
                                 case "Sunny":
                                     DistantRoost.Sunny(rampFog, sceneName, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Overcast":
                                     DistantRoost.Overcast(rampFog, sceneName);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Night":
                                     DistantRoost.Night(rampFog, sceneName, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.NightNature);
                                     break;
 
                                 case "Abyssal":
                                     DistantRoost.Abyssal(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.WaterStream);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedDistantRoostAltVariant;
@@ -294,50 +273,33 @@ namespace StageAesthetic
                         if (selectedSiphonedForestVariant == "Vanilla")
                         {
                             SiphonedForest.Vanilla();
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                             currentVariantName = "Vanilla";
                         }
                         else
                             switch (selectedSiphonedForestVariant)
                             {
                                 case "Night":
-
                                     SiphonedForest.Night(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.NightNature);
                                     break;
 
                                 case "Morning":
-
                                     SiphonedForest.Morning(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Purple":
-
                                     SiphonedForest.Purple(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Crimson":
                                     SiphonedForest.Crimson(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Rain);
                                     break;
 
                                 case "Desolate":
                                     SiphonedForest.Desolate(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedSiphonedForestVariant;
@@ -361,8 +323,8 @@ namespace StageAesthetic
                         if (selectedTitanicPlainsVariant == "Vanilla")
                         {
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.DayNature);
+
+
                         }
                         else
                             switch (selectedTitanicPlainsVariant)
@@ -374,33 +336,23 @@ namespace StageAesthetic
 
                                 case "Sunset":
                                     TitanicPlains.Sunset(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Overcast":
                                     TitanicPlains.Overcast(rampFog, sceneName);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Night":
                                     GameObject.Destroy(volume);
                                     TitanicPlains.Night(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.NightNature);
                                     break;
 
                                 case "Abandoned":
                                     TitanicPlains.Abandoned(rampFog, ppGoolake);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
                             }
                         currentVariantName = selectedTitanicPlainsVariant;
@@ -410,6 +362,37 @@ namespace StageAesthetic
 
                         break;
 
+                    case "village":
+
+                        #region ShatteredAbodes
+                        int shatteredAbodesCounter = rng.RangeInt(0, shatteredAbodesList.Count);
+
+                        if (shatteredAbodesList.Count > 1 && shatteredAbodesCounter == shatteredAbodesVariant)
+                            shatteredAbodesCounter = (shatteredAbodesCounter + 1) % shatteredAbodesList.Count;
+
+                        string[] shatteredAbodesArray = shatteredAbodesList.ToArray();
+                        string selectedShatteredAbodesVariant = shatteredAbodesArray[shatteredAbodesCounter];
+
+                        if (selectedShatteredAbodesVariant == "Vanilla")
+                        {
+                            currentVariantName = "Vanilla";
+                        }
+                        else
+                            switch (selectedShatteredAbodesVariant)
+                            {
+                                case "Verdant":
+                                    ShatteredAbodes.Verdant(rampFog, colorGrading);
+                                    break;
+                                case "Abandoned":
+                                    ShatteredAbodes.Abandoned(rampFog, ppGoolake);
+                                    break;
+                            }
+
+                        currentVariantName = selectedShatteredAbodesVariant;
+                        shatteredAbodesVariant = shatteredAbodesCounter;
+
+                        #endregion ShatteredAbodes
+                        break;
                     case "goolake":
 
                         #region AbandonedAqueduct
@@ -425,8 +408,8 @@ namespace StageAesthetic
                         {
                             if (AbandonedAqueductChanges.Value)
                                 AbandonedAqueduct.VanillaChanges();
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
+
+
                             currentVariantName = "Vanilla";
                         }
                         else
@@ -434,32 +417,22 @@ namespace StageAesthetic
                             {
                                 case "Dawn":
                                     AbandonedAqueduct.Dawn(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Sunrise":
                                     AbandonedAqueduct.Sunrise(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Night":
                                     AbandonedAqueduct.Night(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.NightNature);
                                     break;
 
                                 case "Sundered":
                                     AbandonedAqueduct.Sundered(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Rain);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedAbandonedAqueductVariant;
@@ -483,40 +456,28 @@ namespace StageAesthetic
                         if (selectedAphelianSanctuaryVariant == "Vanilla")
                         {
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                         }
                         else
                             switch (selectedAphelianSanctuaryVariant)
                             {
                                 case "Singularity":
                                     AphelianSanctuary.Singularity(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Twilight":
                                     AphelianSanctuary.Twilight(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Sunset":
                                     AphelianSanctuary.Sunset(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Abyssal":
                                     AphelianSanctuary.Abyssal(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedAphelianSanctuaryVariant;
@@ -525,7 +486,7 @@ namespace StageAesthetic
                         #endregion AphelianSanctuary
 
                         break;
-
+                    /*
                     case "drybasin":
 
                         #region DryBasin
@@ -535,7 +496,7 @@ namespace StageAesthetic
                         #endregion DryBasin
 
                         break;
-
+                    */
                     case "foggyswamp":
 
                         #region WetlandAspect
@@ -550,40 +511,28 @@ namespace StageAesthetic
                         if (selectedWetlandAspectVariant == "Vanilla")
                         {
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                         }
                         else
                             switch (selectedWetlandAspectVariant)
                             {
                                 case "Sunset":
                                     WetlandAspect.Sunset(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Morning":
                                     WetlandAspect.Morning(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Night":
                                     WetlandAspect.Night(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Rain);
                                     break;
 
                                 case "Void":
                                     WetlandAspect.Void(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedWetlandAspectVariant;
@@ -608,41 +557,28 @@ namespace StageAesthetic
                         {
                             RallypointDelta.VanillaChanges();
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                         }
                         else
                             switch (selectedRallypointDeltaVariant)
                             {
                                 case "Night":
-
                                     RallypointDelta.Night(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.NightNature);
                                     break;
 
                                 case "Overcast":
                                     RallypointDelta.Overcast(rampFog, volume);
-                                    StopSounds();
-                                    PlaySound(SoundType.Rain);
                                     break;
 
                                 case "Sunset":
                                     RallypointDelta.Sunset(rampFog, volume);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Titanic":
                                     RallypointDelta.Titanic(rampFog, colorGrading, volume);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedRallypointDeltaVariant;
@@ -668,52 +604,36 @@ namespace StageAesthetic
                             if (ScorchedAcresChanges.Value)
                                 ScorchedAcres.VanillaChanges();
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.DayNature);
                         }
                         else
                             switch (selectedScorchedAcresVariant)
                             {
                                 case "Sunset":
                                     ScorchedAcres.Sunset(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Night":
                                     ScorchedAcres.Night(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Jade":
                                     ScorchedAcres.Jade(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Sunny Beta":
                                     ScorchedAcres.SunnyBeta(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Crimson Beta":
                                     ScorchedAcres.CrimsonBeta(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Twilight":
                                     ScorchedAcres.Twilight(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
                             }
                         currentVariantName = selectedScorchedAcresVariant;
@@ -737,34 +657,26 @@ namespace StageAesthetic
                         {
                             SulfurPools.Vanilla();
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.WaterStream);
+
+
                         }
                         else
                             switch (selectedSulfurPoolsVariant)
                             {
                                 case "Coral":
                                     SulfurPools.Coral(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.WaterStream);
                                     break;
 
                                 case "Hell":
                                     SulfurPools.Hell(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Void":
                                     SulfurPools.Void(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.WaterStream);
                                     break;
                             }
                         currentVariantName = selectedSulfurPoolsVariant;
@@ -788,35 +700,24 @@ namespace StageAesthetic
                         if (selectedFogboundLagoonVariant == "Vanilla")
                         {
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.WaterStream);
                         }
                         else
                             switch (selectedFogboundLagoonVariant)
                             {
                                 case "Clear":
                                     FogboundLagoon.Clear(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
-                                    PlaySound(SoundType.WaterStream);
                                     break;
 
                                 case "Twilight":
                                     FogboundLagoon.Twilight(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.WaterStream);
                                     break;
 
                                 case "Overcast":
                                     FogboundLagoon.Overcast(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.WaterStream);
                                     break;
                             }
                         currentVariantName = selectedFogboundLagoonVariant;
@@ -842,8 +743,6 @@ namespace StageAesthetic
                             if (AbyssalDepthsChanges.Value)
                                 AbyssalDepths.VanillaChanges();
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                         }
                         else
                         {
@@ -855,32 +754,22 @@ namespace StageAesthetic
                             {
                                 case "Blue":
                                     AbyssalDepths.Blue(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Night":
                                     AbyssalDepths.Night(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Orange":
                                     AbyssalDepths.Orange(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Coral":
                                     AbyssalDepths.Coral(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         }
@@ -905,40 +794,28 @@ namespace StageAesthetic
                         if (selectedSirensCallVariant == "Vanilla")
                         {
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                         }
                         else
                             switch (selectedSirensCallVariant)
                             {
                                 case "Night":
                                     SirensCall.Night(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.NightNature);
                                     break;
 
                                 case "Sunny":
                                     SirensCall.Sunny(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Overcast":
                                     SirensCall.Overcast(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Aphelian":
                                     SirensCall.Aphelian(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedSirensCallVariant;
@@ -963,40 +840,28 @@ namespace StageAesthetic
                         {
                             SunderedGrove.Vanilla();
                             currentVariantName = "Vanilla";
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
                         }
                         else
                             switch (selectedSunderedGroveVariant)
                             {
                                 case "Jade":
                                     SunderedGrove.Jade(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Sunny":
                                     SunderedGrove.Sunny(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Overcast":
                                     SunderedGrove.Overcast(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Abandoned":
                                     SunderedGrove.Abandoned(rampFog, ppGoolake);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedSunderedGroveVariant;
@@ -1021,8 +886,6 @@ namespace StageAesthetic
                         {
                             if (SkyMeadowChanges.Value)
                                 SkyMeadow.VanillaChanges();
-                            StopSounds();
-                            PlaySound(SoundType.DayNature);
                             currentVariantName = "Vanilla";
                         }
                         else
@@ -1030,38 +893,26 @@ namespace StageAesthetic
                             {
                                 case "Night":
                                     SkyMeadow.Night(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.NightNature);
                                     break;
 
                                 case "Overcast":
                                     SkyMeadow.Overcast(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Abyssal":
                                     SkyMeadow.Abyssal(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Rain);
                                     break;
 
                                 case "Titanic":
                                     SkyMeadow.Titanic(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
 
                                 case "Abandoned":
                                     SkyMeadow.Abandoned(rampFog, ppGoolake);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.DayNature);
                                     break;
                             }
                         currentVariantName = selectedSkyMeadowVariant;
@@ -1070,7 +921,7 @@ namespace StageAesthetic
                         #endregion SkyMeadow
 
                         break;
-
+                    /*
                     case "slumberingsatellite":
 
                         #region SlumberingSatellite
@@ -1080,7 +931,7 @@ namespace StageAesthetic
                         #endregion SlumberingSatellite
 
                         break;
-
+                    */
                     case "moon2":
 
                         #region Commencement
@@ -1101,26 +952,18 @@ namespace StageAesthetic
                             {
                                 case "Night":
                                     Commencement.Night(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Storm);
                                     break;
 
                                 case "Crimson":
                                     Commencement.Crimson(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Rain);
                                     break;
 
                                 case "Corruption":
                                     Commencement.Corruption(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Rain);
                                     break;
 
                                 case "Gray":
                                     Commencement.Gray(rampFog);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
@@ -1154,26 +997,18 @@ namespace StageAesthetic
                             {
                                 case "Twilight":
                                     VoidLocus.Twilight(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Pink":
                                     VoidLocus.Pink(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 case "Blue":
                                     VoidLocus.Blue(rampFog, colorGrading);
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
 
                                 default:
                                     SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                                    StopSounds();
-                                    PlaySound(SoundType.Wind);
                                     break;
                             }
                         currentVariantName = selectedVoidLocusVariant;
@@ -1197,6 +1032,7 @@ namespace StageAesthetic
         public static int siphonedForestVariant = -1;
         public static int titanicPlainsVariant = -1;
         public static int titanicPlainsAltVariant = -1;
+        public static int shatteredAbodesVariant = -1;
 
         public static int abandonedAqueductVariant = -1;
         public static int aphelianSanctuaryVariant = -1;
@@ -1235,6 +1071,7 @@ namespace StageAesthetic
         public static List<string> distantRoostAltList = new();
         public static List<string> siphonedForestList = new();
         public static List<string> titanicPlainsList = new();
+        public static List<string> shatteredAbodesList = new();
 
         public static List<string> abandonedAqueductList = new();
         public static List<string> aphelianSanctuaryList = new();
@@ -1258,7 +1095,7 @@ namespace StageAesthetic
 
         #endregion VariantContainers
     }
-
+    /*
     public class ForgottenRelicsJ
     {
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
@@ -1282,8 +1119,8 @@ namespace StageAesthetic
                 {
                     if (DryBasinChanges.Value)
                         Variants.Stage2.DryBasin.VanillaChanges();
-                    StopSounds();
-                    PlaySound(SoundType.Wind);
+                    
+                    
                     SwapVariants.currentVariantName = "Vanilla";
                 }
                 else
@@ -1291,26 +1128,26 @@ namespace StageAesthetic
                     {
                         case "Morning":
                             Variants.Stage2.DryBasin.Morning(garbage, rampFog2);
-                            StopSounds();
-                            PlaySound(SoundType.DayNature);
+                            
+                            
                             break;
 
                         case "Blue":
                             Variants.Stage2.DryBasin.Blue(garbage, colorGrading, rampFog2);
-                            StopSounds();
-                            PlaySound(SoundType.DayNature);
+                            
+                            
                             break;
 
                         case "Overcast":
                             Variants.Stage2.DryBasin.Overcast(garbage, colorGrading, rampFog2);
-                            StopSounds();
-                            PlaySound(SoundType.Storm);
+                            
+                            
                             break;
 
                         default:
                             SwapVariants.SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
+                            
+                            
                             break;
                     }
                 SwapVariants.currentVariantName = selectedDryBasinVariant;
@@ -1338,34 +1175,34 @@ namespace StageAesthetic
                 {
                     Variants.Stage5.SlumberingSatellite.Vanilla();
                     SwapVariants.currentVariantName = "Vanilla";
-                    StopSounds();
-                    PlaySound(SoundType.Wind);
+                    
+                    
                 }
                 else
                     switch (selectedSlumberingSatelliteVariant)
                     {
                         case "Morning":
                             Variants.Stage5.SlumberingSatellite.Morning(garbage, rampFog2);
-                            StopSounds();
-                            PlaySound(SoundType.DayNature);
+                            
+                            
                             break;
 
                         case "Overcast":
                             Variants.Stage5.SlumberingSatellite.Overcast(garbage, rampFog2);
-                            StopSounds();
-                            PlaySound(SoundType.Storm);
+                            
+                            
                             break;
 
                         case "Blue":
                             Variants.Stage5.SlumberingSatellite.Blue(garbage, rampFog2);
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
+                            
+                            
                             break;
 
                         default:
                             SwapVariants.SALogger.LogDebug("uwu I messed something up forgive me >w<");
-                            StopSounds();
-                            PlaySound(SoundType.Wind);
+                            
+                            
                             break;
                     }
                 SwapVariants.currentVariantName = selectedSlumberingSatelliteVariant;
@@ -1373,4 +1210,5 @@ namespace StageAesthetic
             }
         }
     }
+    */
 }

--- a/SA.Content/Variants/Special/ReformedAltar.cs
+++ b/SA.Content/Variants/Special/ReformedAltar.cs
@@ -1,0 +1,139 @@
+using RoR2;
+using UnityEngine.Rendering.PostProcessing;
+using UnityEngine;
+using R2API.Utils;
+
+namespace StageAesthetic.Variants.Special
+{
+  internal class ReformedAltar
+  {
+    public static void Verdant(RampFog fog)
+    {
+      fog.fogColorStart.value = new Color32(53, 66, 82, 18);
+      fog.fogColorMid.value = new Color32(103, 67, 64, 154);
+      fog.fogColorEnd.value = new Color32(146, 176, 255, 255);
+      fog.fogOne.value = 0.2f;
+      fog.fogZero.value = -0.05f;
+
+      GameObject sun = GameObject.Find("Directional Light (SUN)");
+      var sunLight = sun.GetComponent<Light>();
+      sunLight.color = new Color32(255, 246, 180, 255);
+
+      Material terrainMat = new Material(Main.verdantTerrainMat);
+      Material detailMat = Main.verdantDetailMat;
+      Material detailMat2 = new Material(Main.reformedAltarTempleMat);
+      Material detailMat22 = Main.verdantDetailMat2;
+      Material detailMat3 = Main.verdantDetailMat3;
+      Material grassMat = Main.verdantGrassMat;
+      Material grassBlueMat = Main.verdantBlueGrassMat;
+      // terrainMat.shaderKeywords = new string[] { "DOUBLESAMPLE", "MICROFACET_SNOW", "USE_ALPHA_AS_MASK", "USE_VERTEX_COLORS", "USE_VERTICAL_BIAS", "BINARYBLEND" };
+      // _MainTex texTLTrimBasecolor
+      // _NormalTex texTLTrimNormal
+      // _SnowTex texTLTerrainGrassGreen
+      // _SnowNormalTex null
+      // _DirtTex texTLShipRustBasecolor
+      // _DirtNormalTex null
+
+      detailMat2.SetTexture("_GreenChannelTex", detailMat22.GetTexture("_SnowTex"));
+      detailMat2.SetTexture("_BlueChannelTex", detailMat22.GetTexture("_MainTex"));
+      detailMat2.SetTexture("_RedChannelTopTex", detailMat22.GetTexture("_DirtTex"));
+      detailMat2.SetTexture("_RedChannelSideTex", detailMat22.GetTexture("_DirtTex"));
+      // _GreenChannelTex sand
+      // _RedChannelTopTex 
+      // _RedChannelSideTex
+      MeshRenderer[] meshList = Resources.FindObjectsOfTypeAll(typeof(MeshRenderer)) as MeshRenderer[];
+      foreach (MeshRenderer renderer in meshList)
+      {
+        GameObject meshBase = renderer.gameObject;
+        if (meshBase != null)
+        {
+          if (meshBase.name.Contains("GrassSmall") && renderer.sharedMaterial)
+          {
+            // 0.3786 0.6321 0.5703 1
+            renderer.sharedMaterial.color = new Color(0.3786f, 0.6321f, 0.5703f, 1);
+          }
+        }
+      }
+      AltarMaterials(terrainMat, detailMat, detailMat2, detailMat3, grassBlueMat);
+    }
+
+    public static void Helminth(RampFog fog)
+    {
+      fog.fogColorEnd.value = new Color(0.3208f, 0.1234f, 0.1044f, 1f);
+      fog.fogColorMid.value = new Color(0.5176f, 0.3338f, 0.2706f, 0.4471f);
+      fog.fogColorStart.value = new Color(0.7453f, 0.3527f, 0.2988f, 0f);
+
+      // intensity 0.588
+      // fogone 0.601
+      // texHRCrystalDiffuse blue
+      // texHRTerrainHorizontalDiffuse green
+      // texHRWallBrickColor redtop
+      // 1 0.7468 0.5868 1
+      GameObject.Find("Leaves").SetActive(false);
+      GameObject.Find("FallenLeaf").SetActive(false);
+      GameObject.Find("LTVineHanging").SetActive(false);
+      GameObject.Find("LTVineHangingB").SetActive(false);
+
+      GameObject sun = GameObject.Find("Directional Light (SUN)");
+      Light sunLight = sun.GetComponent<Light>();
+      sunLight.color = new Color(0.5647f, 0.8706f, 0.8863f, 1);
+
+      MeshRenderer[] meshList = Resources.FindObjectsOfTypeAll(typeof(MeshRenderer)) as MeshRenderer[];
+      foreach (MeshRenderer renderer in meshList)
+      {
+        GameObject meshBase = renderer.gameObject;
+        if (meshBase != null)
+        {
+          if (meshBase.name.Contains("LTCrystals") && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = Main.helminthObsidianMat;
+          }
+          if (meshBase.name.Contains("GrassSmall") && renderer.sharedMaterial)
+          {
+            // 0.3786 0.6321 0.5703 1
+            renderer.sharedMaterial.color = new Color(1f, 0.7468f, 0.5868f, 1);
+          }
+        }
+      }
+
+      Material terrainMat = new Material(Main.helminthTerrainMat);
+      terrainMat.SetTexture("_GreenChannelTex", Main.helminthTerrainMat.GetTexture("_BlueChannelTex"));
+      terrainMat.SetTexture("_BlueChannelTex", Main.helminthTerrainMat.GetTexture("_GreenChannelTex"));
+      Material detailMat2 = new Material(Main.helminthDetailMat2);
+      detailMat2.shaderKeywords = new string[] { "DOUBLESAMPLE", "MICROFACET_SNOW", "USE_ALPHA_AS_MASK", "USE_VERTEX_COLORS", "USE_VERTICAL_BIAS", "BINARYBLEND" };
+      AltarMaterials(terrainMat, Main.helminthDetailMat, detailMat2, Main.helminthDetailMat3, Main.helminthGrassMat2);
+    }
+    private static void AltarMaterials(Material terrainMat, Material detailMat, Material detailMat2, Material detailMat3, Material grassMat2)
+    {
+
+      MeshRenderer[] meshList = Resources.FindObjectsOfTypeAll(typeof(MeshRenderer)) as MeshRenderer[];
+      foreach (MeshRenderer renderer in meshList)
+      {
+        GameObject meshBase = renderer.gameObject;
+        if (meshBase != null)
+        {
+          if (grassMat2 && meshBase.name.Contains("GrassTall") && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = grassMat2;
+          }
+          if ((meshBase.name.Contains("LTTerrain") || meshBase.name.Contains("Dune")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = terrainMat;
+          }
+          if ((meshBase.name.Contains("LTCeiling") || meshBase.name.Contains("LTTemple") || meshBase.name.Contains("Altar") || meshBase.name.Contains("Arches") || meshBase.name.Contains("LTColumn") || meshBase.name.Contains("LTStairs")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = detailMat2;
+          }
+          if ((meshBase.name.Contains("LTCeilingRoots") || meshBase.name.Contains("Tube")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = detailMat3;
+          }
+          if ((meshBase.name.Contains("Gold") || meshBase.name.Contains("Boulder") || meshBase.name.Contains("Coral") || meshBase.name.Contains("Crystal")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = detailMat;
+          }
+        }
+      }
+    }
+  }
+}

--- a/SA.Content/Variants/Special/TreebornColony.cs
+++ b/SA.Content/Variants/Special/TreebornColony.cs
@@ -1,0 +1,57 @@
+using RoR2;
+using UnityEngine.Rendering.PostProcessing;
+using UnityEngine;
+using R2API.Utils;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace StageAesthetic.Variants.Special
+{
+  internal class TreebornColony
+  {
+
+    public static void Night()
+    {
+      Skybox.NightSky();
+      GameObject.Find("meshBHFog").SetActive(false);
+      GameObject.Find("Weather, Habitat").SetActive(false);
+    }
+
+    public static void Meridian(RampFog fog)
+    {
+      AddRain(RainType.Typhoon);
+      fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+      fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.2941f);
+      fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0);
+      fog.fogPower.value = 0.5f;
+      fog.fogZero.value = -0.02f;
+      fog.fogOne.value = 0.05f;
+
+      GameObject.Find("BHGodRay").SetActive(false);
+      GameObject.Find("Directional Light (SUN)").GetComponent<Light>().color = new Color(0.7529f, 0.7137f, 0.6157f, 1);
+      GameObject.Find("meshBHFog").GetComponent<MeshRenderer>().sharedMaterial = Main.meridianStormCloudMat;
+      GameObject wind = GameObject.Find("WindZone");
+      var windZone = wind.GetComponent<WindZone>();
+      windZone.windMain = 0.5f;
+      windZone.windTurbulence = 0.65f;
+      windZone.mode = WindZoneMode.Directional;
+      windZone.radius = 100;
+    }
+
+    public static void Sunny(RampFog fog)
+    {
+      fog.fogColorStart.value = new Color32(53, 66, 82, 18);
+      fog.fogColorMid.value = new Color32(103, 67, 64, 154);
+      fog.fogColorEnd.value = new Color32(146, 176, 255, 255);
+      // 0.6078 0.6431 0.5373 1
+      fog.fogOne.value = 0.2f;
+      fog.fogZero.value = -0.05f;
+      fog.fogPower.value = 1f;
+      GameObject.Find("meshBHFog").SetActive(false);
+      GameObject sun = GameObject.Find("Directional Light (SUN)");
+      sun.transform.eulerAngles = new Vector3(90, 0, 0); // 64.0354 107.4961 67.9778
+      var sunLight = sun.GetComponent<Light>();
+      sunLight.color = new Color32(255, 246, 180, 255);
+    }
+  }
+}

--- a/SA.Content/Variants/Special/VoidLocus.cs
+++ b/SA.Content/Variants/Special/VoidLocus.cs
@@ -1,7 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.Rendering.PostProcessing;
-using static UnityEngine.Experimental.TerrainAPI.TerrainUtility;
 
 namespace StageAesthetic.Variants.Special
 {

--- a/SA.Content/Variants/Stage1/DistantRoost.cs
+++ b/SA.Content/Variants/Stage1/DistantRoost.cs
@@ -15,7 +15,7 @@ namespace StageAesthetic.Variants.Stage1
 
         public static void Sunny(RampFog fog, string scenename, ColorGrading cgrade)
         {
-            Skybox.SunnyDistantRoostSky();
+            Skybox.DaySky();
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             sunLight.color = new Color32(255, 246, 229, 255);
             sunLight.intensity = 1.8f;

--- a/SA.Content/Variants/Stage1/DistantRoost.cs
+++ b/SA.Content/Variants/Stage1/DistantRoost.cs
@@ -98,14 +98,14 @@ namespace StageAesthetic.Variants.Stage1
         public static void Overcast(RampFog fog, string scenename)
         {
             AddRain(RainType.Typhoon);
-            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
-            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 0.95f);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 0.5f;
+            fog.fogPower.value = 2f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
-            fog.skyboxStrength.value = 0.03f;
-            fog.fogIntensity.value = 0.88f;
+            fog.skyboxStrength.value = 0f;
+            fog.fogIntensity.value = 1f;
 
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             sunLight.color = new Color32(77, 188, 175, 255);
@@ -164,7 +164,7 @@ namespace StageAesthetic.Variants.Stage1
             // cgrade.colorFilter.overrideState = true;
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             sunLight.color = new Color(0.75f, 0.75f, 0.75f, 1f);
-            sunLight.intensity = 5f;
+            sunLight.intensity = 3f;
             sunLight.shadowStrength = 0.75f;
             sunLight.transform.eulerAngles = new Vector3(70f, 220f, -9.985f);
             var shadows = sunLight.gameObject.GetComponent<NGSS_Directional>();

--- a/SA.Content/Variants/Stage1/DistantRoost.cs
+++ b/SA.Content/Variants/Stage1/DistantRoost.cs
@@ -97,21 +97,23 @@ namespace StageAesthetic.Variants.Stage1
 
         public static void Overcast(RampFog fog, string scenename)
         {
-            fog.fogColorStart.value = new Color32(31, 46, 63, 50);
-            fog.fogColorMid.value = new Color(0.205f, 0.269f, 0.288f, 0.76f);
-            fog.fogColorEnd.value = new Color32(71, 82, 88, 255);
-            fog.skyboxStrength.value = 0.02f;
-            fog.fogPower.value = 0.35f;
-            fog.fogIntensity.value = 0.88f;
+            AddRain(RainType.Typhoon);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
+            fog.fogPower.value = 0.5f;
             fog.fogZero.value = -0.02f;
-            fog.fogOne.value = 0.05f;
+            fog.fogOne.value = 0.025f;
+            fog.skyboxStrength.value = 0.03f;
+            fog.fogIntensity.value = 0.88f;
+
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             sunLight.color = new Color32(77, 188, 175, 255);
             sunLight.intensity = 1.7f;
             sunLight.shadowStrength = 0.6f;
             var shadows = sunLight.gameObject.GetComponent<NGSS_Directional>();
             shadows.NGSS_SHADOWS_RESOLUTION = NGSS_Directional.ShadowMapResolution.UseQualitySettings;
-            Utils.AddRain(Utils.RainType.Monsoon);
+
             GameObject wind = GameObject.Find("WindZone");
             wind.transform.eulerAngles = new Vector3(30, 20, 0);
             var windZone = wind.GetComponent<WindZone>();

--- a/SA.Content/Variants/Stage1/DistantRoost.cs
+++ b/SA.Content/Variants/Stage1/DistantRoost.cs
@@ -85,7 +85,7 @@ namespace StageAesthetic.Variants.Stage1
                 }
             }
             AddSnow(SnowType.Light, -10f);
-            s.GetChild(19).GetChild(0).localPosition = new Vector3(0, 0, -10);
+            // s.GetChild(19).GetChild(0).localPosition = new Vector3(0, 0, -10); something moved/broke with this
 
             GameObject.Find("HOLDER: Grass").SetActive(false);
             GameObject.Find("FOLIAGE").SetActive(false);
@@ -149,15 +149,15 @@ namespace StageAesthetic.Variants.Stage1
 
         public static void Abyssal(RampFog fog, ColorGrading cgrade)
         {
-            fog.fogColorStart.value = new Color32(99, 27, 63, 72);
-            fog.fogColorMid.value = new Color32(26, 61, 91, 70);
-            fog.fogColorEnd.value = new Color32(68, 27, 27, 155);
+            fog.fogColorStart.value = new Color32(99, 27, 63, 25);
+            fog.fogColorMid.value = new Color32(26, 61, 91, 150);
+            fog.fogColorEnd.value = new Color32(68, 27, 27, 255);
             fog.SetAllOverridesTo(true);
-            fog.skyboxStrength.value = 0f;
+            fog.skyboxStrength.value = 0.1f;
             fog.fogPower.value = 1f;
-            fog.fogIntensity.value = 0.9f;
+            fog.fogIntensity.value = 1f;
             fog.fogZero.value = -0.05f;
-            fog.fogOne.value = 0.27f;
+            fog.fogOne.value = 0.2f;
             //  cgrade.colorFilter.value = new Color32(150, 150, 150, 255);
             // cgrade.colorFilter.overrideState = true;
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
@@ -430,8 +430,8 @@ namespace StageAesthetic.Variants.Stage1
             {
                 // GameObject.Find("GAMEPLAY SPACE").transform.GetChild(7).GetChild(0).GetComponent<MeshRenderer>().sharedMaterial = terrainMat;
                 // GameObject.Find("GAMEPLAY SPACE").transform.GetChild(7).GetChild(1).GetComponent<MeshRenderer>().sharedMaterial = terrainMat;
-                GameObject.Find("GAMEPLAY SPACE").transform.GetChild(7).GetChild(0).GetComponent<MeshRenderer>().sharedMaterial = Main.distantRoostVoidTerrainMat;
-                GameObject.Find("GAMEPLAY SPACE").transform.GetChild(7).GetChild(1).GetComponent<MeshRenderer>().sharedMaterial = Main.distantRoostVoidTerrainMat;
+                GameObject.Find("GAMEPLAY SPACE").transform.GetChild(1).GetChild(0).GetComponent<MeshRenderer>().sharedMaterial = Main.distantRoostVoidTerrainMat;
+                GameObject.Find("GAMEPLAY SPACE").transform.GetChild(1).GetChild(2).GetComponent<MeshRenderer>().sharedMaterial = Main.distantRoostVoidTerrainMat;
                 var meshList = Object.FindObjectsOfType(typeof(MeshRenderer)) as MeshRenderer[];
                 foreach (MeshRenderer mr in meshList)
                 {

--- a/SA.Content/Variants/Stage1/ShatteredAbodes.cs
+++ b/SA.Content/Variants/Stage1/ShatteredAbodes.cs
@@ -12,16 +12,18 @@ namespace StageAesthetic.Variants.Stage1
     {
       // Skybox.DaySky();
 
-      fog.fogColorStart.value = new Color32(128, 121, 99, 13);
-      fog.fogColorMid.value = new Color32(106, 141, 154, 130);
-      fog.fogColorEnd.value = new Color32(104, 150, 199, 255);
+      fog.fogColorStart.value = new Color32(53, 66, 82, 18);
+      fog.fogColorMid.value = new Color32(103, 67, 64, 154);
+      fog.fogColorEnd.value = new Color32(146, 176, 255, 255);
+      fog.fogOne.value = 0.2f;
+      fog.fogZero.value = -0.05f;
 
       GameObject rainParticles = GameObject.Find("CAMERA PARTICLES: RainParticles (1)");
       rainParticles.SetActive(false);
       GameObject sun = GameObject.Find("Directional Light (SUN)");
       sun.transform.eulerAngles = new Vector3(60f, 65f, 210f);
       var sunLight = sun.GetComponent<Light>();
-      sunLight.color = new Color32(255, 246, 229, 255);
+      sunLight.color = new Color32(255, 246, 180, 255);
       sunLight.intensity = 0.8f;
       sunLight.shadowStrength = 0.7f;
       // 30.512 64.27 209.701

--- a/SA.Content/Variants/Stage1/ShatteredAbodes.cs
+++ b/SA.Content/Variants/Stage1/ShatteredAbodes.cs
@@ -1,0 +1,104 @@
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.Rendering.PostProcessing;
+using Object = UnityEngine.Object;
+
+namespace StageAesthetic.Variants.Stage1
+{
+  internal class ShatteredAbodes
+  {
+
+    public static void Verdant(RampFog fog, ColorGrading cgrade)
+    {
+      // Skybox.DaySky();
+
+      fog.fogColorStart.value = new Color32(128, 121, 99, 13);
+      fog.fogColorMid.value = new Color32(106, 141, 154, 130);
+      fog.fogColorEnd.value = new Color32(104, 150, 199, 255);
+
+      GameObject rainParticles = GameObject.Find("CAMERA PARTICLES: RainParticles (1)");
+      rainParticles.SetActive(false);
+      GameObject sun = GameObject.Find("Directional Light (SUN)");
+      sun.transform.eulerAngles = new Vector3(60f, 65f, 210f);
+      var sunLight = sun.GetComponent<Light>();
+      sunLight.color = new Color32(255, 246, 229, 255);
+      sunLight.intensity = 0.8f;
+      sunLight.shadowStrength = 0.7f;
+      // 30.512 64.27 209.701
+      var shadows = sunLight.gameObject.GetComponent<NGSS_Directional>();
+      shadows.NGSS_SHADOWS_RESOLUTION = NGSS_Directional.ShadowMapResolution.UseQualitySettings;
+      cgrade.colorFilter.value = new Color32(255, 234, 194, 255);
+      cgrade.colorFilter.overrideState = true;
+      AbodesMaterials(Main.verdantTerrainMat, Main.verdantDetailMat, Main.verdantDetailMat2, Main.verdantDetailMat3);
+    }
+
+    public static void Abandoned(RampFog fog, PostProcessProfile ppProfile)
+    {
+      // Skybox.SunnyDistantRoostSky();
+      GameObject rainParticles = GameObject.Find("CAMERA PARTICLES: RainParticles (1)");
+      rainParticles.SetActive(false);
+      GameObject grassParticles = GameObject.Find("LVCameraParticlesGrass");
+      grassParticles.SetActive(false);
+      AddSand(SandType.Gigachad);
+
+      GameObject sun = GameObject.Find("Directional Light (SUN)");
+
+      RampFog rampFog = ppProfile.GetSetting<RampFog>();
+      fog.fogColorStart.value = new Color(0.49f, 0.363f, 0.374f, 0.1f);
+      fog.fogColorMid.value = new Color(0.58f, 0.486f, 0.331f, 0.25f);
+      fog.fogColorEnd.value = new Color(0.77f, 0.839f, 0.482f, 0.5f);
+      fog.fogZero.value = rampFog.fogZero.value;
+      fog.fogIntensity.value = rampFog.fogIntensity.value;
+      fog.fogPower.value = rampFog.fogPower.value;
+      fog.fogOne.value = rampFog.fogOne.value;
+      fog.skyboxStrength.value = 0.02f;
+      // sun.transform.eulerAngles = new Vector3(45f, 200f, 0f);
+      var sunLight = sun.GetComponent<Light>();
+      sunLight.color = new Color(1f, 0.65f, 0.5f, 1f);
+      sunLight.intensity = 1.6f;
+      sunLight.shadowStrength = 0.7f;
+      // 30.512 64.27 209.701
+      AbodesMaterials(Main.plainsAbandonedTerrainMat, Main.plainsAbandonedDetailMat, Main.plainsAbandonedDetailMat2, Main.groveAbandonedDetailMat2);
+    }
+    public static void AbodesMaterials(Material terrainMat, Material detailMat, Material detailMat2, Material detailMat3)
+    {
+
+      MeshRenderer[] meshList = Resources.FindObjectsOfTypeAll(typeof(MeshRenderer)) as MeshRenderer[];
+      foreach (MeshRenderer renderer in meshList)
+      {
+        GameObject meshBase = renderer.gameObject;
+        if (meshBase != null)
+        {
+          if ((meshBase.name.Contains("Grass") || meshBase.name.Contains("Fern")) && renderer.sharedMaterial)
+          {
+            GameObject.Destroy(meshBase);
+          }
+          if ((meshBase.name.Contains("HouseBuried") || meshBase.name.Contains("LVTerrain") || meshBase.name.Contains("LVArc_StormOutlook") || meshBase.name.Contains("BuriedHouse")) && renderer.sharedMaterials.Length == 2)
+          {
+            renderer.sharedMaterials = new Material[] { terrainMat, detailMat2 };
+          }
+          if ((meshBase.name.Contains("LVTerrainToggle") || meshBase.name.Contains("LVTerrainFar") || meshBase.name.Contains("Dune") || meshBase.name.Contains("BrokenAltar") || meshBase.name.Contains("LVTerrainBackground")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = terrainMat;
+          }
+          if ((meshBase.name.Contains("LVArc_Temple") || meshBase.name.Contains("LVArc_Houses") || meshBase.name.Contains("LVArc_CliffCave") || meshBase.name.Contains("LVArc_Bridge") || meshBase.name.Contains("LVArc_BrokenPillar")) && renderer.sharedMaterials.Length == 2)
+          {
+            renderer.sharedMaterials = new Material[] { detailMat2, terrainMat };
+          }
+          if (meshBase.name.Contains("Pillar") && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = detailMat2;
+          }
+          if ((meshBase.name.Contains("RockMedium") || meshBase.name.Contains("Pebble")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = detailMat;
+          }
+          if (meshBase.name.Contains("Crystal") && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = detailMat3;
+          }
+        }
+      }
+    }
+  }
+}

--- a/SA.Content/Variants/Stage1/SiphonedForest.cs
+++ b/SA.Content/Variants/Stage1/SiphonedForest.cs
@@ -49,19 +49,32 @@ namespace StageAesthetic.Variants.Stage1
 
         public static void Crimson(RampFog fog, ColorGrading cgrade)
         {
+            /*
+      // fog end 0.3208 0.1234 0.1044 1
+      // fog mid 0.5176 0.3338 0.2706 0.4471
+      // fog start 0.7453 0.3527 0.2988 0
             fog.fogColorStart.value = new Color32(140, 70, 70, 0);
             fog.fogColorMid.value = new Color32(120, 50, 40, 75);
             fog.fogColorEnd.value = new Color32(90, 35, 46, 150);
+            */
+            fog.fogColorStart.value = new Color(0.7453f, 0.3527f, 0.2988f, 0);
+            fog.fogColorMid.value = new Color(0.6176f, 0.3338f, 0.2706f, 0.4471f);
+            fog.fogColorEnd.value = new Color(0.4208f, 0.1234f, 0.1044f, 0.75f);
             fog.SetAllOverridesTo(true);
             fog.skyboxStrength.value = 0.01f;
+            fog.fogPower.value = 1f;
+            fog.fogOne.value = 0.2f;
+            fog.fogZero.value = -0.02f;
+            /*
             fog.fogPower.value = 0.35f;
             fog.fogOne.value = 0.108f;
             fog.fogZero.value = -0.007f;
+            */
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             var aurora = GameObject.Find("mdlSnowyForestAurora");
 
             aurora.SetActive(false);
-            sunLight.color = new Color32(200, 150, 150, 255);
+            sunLight.color = new Color32(200, 175, 150, 255);
             sunLight.intensity = 2f;
             sunLight.shadowStrength = 0.5f;
             sunLight.transform.eulerAngles = new Vector3(55f, 0f, 0f);
@@ -152,150 +165,104 @@ namespace StageAesthetic.Variants.Stage1
 
         public static void DesolateMaterials()
         {
-            var normal = Addressables.LoadAssetAsync<Texture2D>("RoR2/Base/Common/texNormalBumpyRock.jpg").WaitForCompletion();
-            var side = Main.stageaesthetic.LoadAsset<Texture2D>("Assets/StageAesthetic/Materials/texRockSide.png");
-            var top = Main.stageaesthetic.LoadAsset<Texture2D>("Assets/StageAesthetic/Materials/texRockTop.png");
+            var terrainMat = Main.siphonedDesolateTerrainMat;
+            var detailMat = Main.siphonedDesolateDetailMat;
+            var detailMat2 = Main.siphonedDesolateDetailMat2;
+            var water = Main.siphonedDesolateWaterMat;
+            var detailMat4 = Main.siphonedDesolateDetailMat4;
+            var detailMat5 = Main.siphonedDesolateDetailMat5;
+            var detailMat6 = Main.siphonedDesolateDetailMat6;
 
-            var terrainMat = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/blackbeach/matBbTerrain.mat").WaitForCompletion());
-            terrainMat.color = new Color32(174, 153, 129, 255);
-            terrainMat.SetFloat("_RedChannelSmoothness", 0.5063887f);
-            terrainMat.SetFloat("_RedChannelBias", 1.2f);
-            terrainMat.SetFloat("_RedChannelSpecularExponent", 20f);
-            terrainMat.SetTexture("_RedChannelSideTex", side);
-            terrainMat.SetTexture("_RedChannelTopTex", top);
-
-            terrainMat.SetFloat("_GreenChannelBias", 1.87f);
-            terrainMat.SetFloat("_GreenChannelSpecularStrength", 0f);
-            terrainMat.SetFloat("_GreenChannelSpecularExponent", 20f);
-            terrainMat.SetFloat("_GreenChannelSmoothnes", 0.4169469f);
-
-            terrainMat.SetFloat("_BlueChannelBias", 1.3f);
-            terrainMat.SetFloat("_BlueChannelSmoothness", 0.3059852f);
-
-            terrainMat.SetFloat("_TextureFactor", 0.06f);
-            terrainMat.SetFloat("_NormalStrength", 0.3f);
-
-            terrainMat.SetFloat("_Depth", 0.1f);
-            terrainMat.SetInt("_RampInfo", 5);
-            terrainMat.SetTexture("_NormalTex", normal);
-
-            var detailMat = Addressables.LoadAssetAsync<Material>("RoR2/Base/blackbeach/matBbBoulder.mat").WaitForCompletion();
-            var detailMat2 = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/DLC1/ancientloft/matAncientLoft_Temple.mat").WaitForCompletion());
-            detailMat2.color = new Color32(18, 79, 40, 255);
-            var water = Addressables.LoadAssetAsync<Material>("RoR2/Base/moon/matMoonWaterBridge.mat").WaitForCompletion();
-            var detailMat4 = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/rootjungle/matRJTree.mat").WaitForCompletion());
-            detailMat4.color = new Color32(205, 104, 12, 255);
-            detailMat4.SetFloat("_Depth", 0.714f);
-            detailMat4.SetFloat("_NormalStrength", 0.25f);
-            detailMat4.SetFloat("_RedChannelBias", 0.17f);
-            detailMat4.SetFloat("_RedChannelSpecularStrength", 0.0338f);
-            detailMat4.SetFloat("_GreenChannelBias", 0f);
-            detailMat4.SetTextureScale("_NormalTex", new Vector2(0.3f, 0.3f));
-            var detailMat5 = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/rootjungle/matRJTree.mat").WaitForCompletion());
-            detailMat5.color = new Color32(255, 255, 255, 255);
-            var detailMat6 = Object.Instantiate(Addressables.LoadAssetAsync<Material>("RoR2/Base/Captain/matCaptainSupplyDropEquipmentRestock.mat").WaitForCompletion());
-            detailMat6.color = new Color32(80, 162, 90, 255);
-
-            SwapVariants.SALogger.LogInfo("Initializing material, if this is null then guhhh... " + terrainMat);
-            SwapVariants.SALogger.LogInfo("Initializing material, if this is null then guhhh... " + detailMat);
-            SwapVariants.SALogger.LogInfo("Initializing material, if this is null then guhhh... " + detailMat2);
-            SwapVariants.SALogger.LogInfo("Initializing material, if this is null then guhhh... " + water);
-            SwapVariants.SALogger.LogInfo("Initializing material, if this is null then guhhh... " + detailMat4);
-            SwapVariants.SALogger.LogInfo("Initializing material, if this is null then guhhh... " + detailMat5);
-            SwapVariants.SALogger.LogInfo("Initializing material, if this is null then guhhh... " + detailMat6);
-
-            if (terrainMat && detailMat && detailMat2 && water && detailMat4 && detailMat5 && detailMat6)
+            var meshList = Object.FindObjectsOfType(typeof(MeshRenderer)) as MeshRenderer[];
+            var particleList = Object.FindObjectsOfType(typeof(ParticleSystem)) as ParticleSystem[];
+            var lightList = Object.FindObjectsOfType(typeof(Light)) as Light[];
+            foreach (Light light in lightList)
             {
-                var meshList = Object.FindObjectsOfType(typeof(MeshRenderer)) as MeshRenderer[];
-                var particleList = Object.FindObjectsOfType(typeof(ParticleSystem)) as ParticleSystem[];
-                var lightList = Object.FindObjectsOfType(typeof(Light)) as Light[];
-                foreach (Light light in lightList)
+                var lightBase = light.gameObject;
+                if (lightBase && !lightBase.name.Contains("Directional Light (SUN)"))
                 {
-                    var lightBase = light.gameObject;
-                    if (lightBase && !lightBase.name.Contains("Directional Light (SUN)"))
+                    light.color = new Color32(53, 56, 148, 255);
+                    light.intensity = 5f;
+                    light.range = 120f;
+                    var flickerLight = light.GetComponent<FlickerLight>();
+                    if (flickerLight)
+                        flickerLight.enabled = false;
+                }
+            }
+            foreach (ParticleSystem ps in particleList)
+            {
+                var particleBase = ps.gameObject;
+                if (particleBase)
+                {
+                    if (particleBase.name.Contains("Fire") || particleBase.name.Contains("HeatGas"))
                     {
-                        light.color = new Color32(53, 56, 148, 255);
-                        light.intensity = 5f;
-                        light.range = 120f;
-                        var flickerLight = light.GetComponent<FlickerLight>();
-                        if (flickerLight)
-                            flickerLight.enabled = false;
+                        particleBase.SetActive(false);
                     }
                 }
-                foreach (ParticleSystem ps in particleList)
+            }
+            foreach (MeshRenderer mr in meshList)
+            {
+                var meshBase = mr.gameObject;
+                if (meshBase != null)
                 {
-                    var particleBase = ps.gameObject;
-                    if (particleBase)
+                    if (meshBase.name.Contains("Terrain") || meshBase.name.Contains("SnowPile"))
                     {
-                        if (particleBase.name.Contains("Fire") || particleBase.name.Contains("HeatGas"))
+                        if (mr.sharedMaterial)
                         {
-                            particleBase.SetActive(false);
+                            mr.sharedMaterial = terrainMat;
                         }
                     }
-                }
-                foreach (MeshRenderer mr in meshList)
-                {
-                    var meshBase = mr.gameObject;
-                    if (meshBase != null)
+                    if (meshBase.name == "SF_GiantTreesTops")
                     {
-                        if (meshBase.name.Contains("Terrain") || meshBase.name.Contains("SnowPile"))
+                        meshBase.gameObject.SetActive(false);
+                    }
+                    if (meshBase.name.Contains("Pebble") || meshBase.name.Contains("Rock") || meshBase.name.Contains("mdlSFCeilingSpikes"))
+                    {
+                        if (mr.sharedMaterial)
                         {
-                            if (mr.sharedMaterial)
-                            {
-                                mr.sharedMaterial = terrainMat;
-                            }
+                            mr.sharedMaterial = detailMat;
                         }
-                        if (meshBase.name == "meshSnowyForestGiantTreesTops")
+                    }
+                    if (meshBase.name.Contains("RuinGate") || meshBase.name.Contains("SF_Aqueduct") || meshBase.name == "meshSnowyForestFirepitFloor" || meshBase.name.Contains("meshSnowyForestFirepitRing") || meshBase.name.Contains("meshSnowyForestFirepitJar") || (meshBase.name.Contains("meshSnowyForestPot") && meshBase.name != "meshSnowyForestPotSap") || meshBase.name.Contains("mdlSFHangingLantern") || meshBase.name.Contains("mdlSFBrokenLantern") || meshBase.name.Contains("meshSnowyForestCrate"))
+                    {
+                        if (mr.sharedMaterial)
                         {
-                            meshBase.gameObject.SetActive(false);
+                            mr.sharedMaterial = detailMat2;
                         }
-                        if (meshBase.name.Contains("Pebble") || meshBase.name.Contains("Rock") || meshBase.name.Contains("mdlSFCeilingSpikes"))
+                    }
+                    if (meshBase.name.Contains("SF_TreeLog") || meshBase.name.Contains("SF_TreeTrunk") || meshBase.name.Contains("SF_GiantTrees") || meshBase.name.Contains("SF_SurroundingTrees"))
+                    {
+                        if (mr.sharedMaterial)
                         {
-                            if (mr.sharedMaterial)
-                            {
-                                mr.sharedMaterial = detailMat;
-                            }
+                            mr.sharedMaterial = detailMat4;
                         }
-                        if (meshBase.name.Contains("RuinGate") || meshBase.name.Contains("meshSnowyForestAqueduct") || meshBase.name == "meshSnowyForestFirepitFloor" || meshBase.name.Contains("meshSnowyForestFirepitRing") || meshBase.name.Contains("meshSnowyForestFirepitJar") || (meshBase.name.Contains("meshSnowyForestPot") && meshBase.name != "meshSnowyForestPotSap") || meshBase.name.Contains("mdlSFHangingLantern") || meshBase.name.Contains("mdlSFBrokenLantern") || meshBase.name.Contains("meshSnowyForestCrate"))
+                    }
+                    if (meshBase.name.Contains("mdlSnowyForestTreeStump"))
+                    {
+                        if (mr.sharedMaterial)
                         {
-                            if (mr.sharedMaterial)
-                            {
-                                mr.sharedMaterial = detailMat2;
-                            }
+                            mr.sharedMaterial = detailMat5;
+                            mr.sharedMaterials[0] = Main.siphonedDesolateTreeRingMat;
+                            mr.sharedMaterials[1] = detailMat5;
                         }
-                        if (meshBase.name.Contains("meshSnowyForestTreeLog") || meshBase.name.Contains("meshSnowyForestTreeTrunk") || meshBase.name.Contains("meshSnowyForestGiantTrees") || meshBase.name.Contains("meshSnowyForestSurroundingTrees"))
+                    }
+                    if (meshBase.name.Contains("mdlSFHangingLanternRope") || meshBase.name.Contains("mdlSFLanternRope"))
+                    {
+                        if (mr.sharedMaterial)
                         {
-                            if (mr.sharedMaterial)
-                            {
-                                mr.sharedMaterial = detailMat4;
-                            }
+                            mr.sharedMaterial = detailMat6;
                         }
-                        if (meshBase.name.Contains("mdlSnowyForestTreeStump"))
+                    }
+                    if (meshBase.name == "meshSnowyForestFirepitFloor (1)" || meshBase.name.Contains("SF_Sap") || meshBase.name.Contains("goo"))
+                    {
+                        if (mr.sharedMaterial)
                         {
-                            if (mr.sharedMaterial)
-                            {
-                                mr.sharedMaterial = detailMat5;
-                                mr.sharedMaterials[1] = detailMat5;
-                            }
+                            mr.sharedMaterial = water;
                         }
-                        if (meshBase.name.Contains("mdlSFHangingLanternRope") || meshBase.name.Contains("mdlSFLanternRope"))
-                        {
-                            if (mr.sharedMaterial)
-                            {
-                                mr.sharedMaterial = detailMat6;
-                            }
-                        }
-                        if (meshBase.name == "meshSnowyForestFirepitFloor (1)" || meshBase.name.Contains("meshSnowyForestSap") || meshBase.name.Contains("goo"))
-                        {
-                            if (mr.sharedMaterial)
-                            {
-                                mr.sharedMaterial = water;
-                            }
-                        }
-                        if (meshBase.name == "meshSnowyForestPotSap")
-                        {
-                            meshBase.SetActive(false);
-                        }
+                    }
+                    if (meshBase.name == "meshSnowyForestPotSap")
+                    {
+                        meshBase.SetActive(false);
                     }
                 }
             }

--- a/SA.Content/Variants/Stage1/SiphonedForest.cs
+++ b/SA.Content/Variants/Stage1/SiphonedForest.cs
@@ -90,10 +90,12 @@ namespace StageAesthetic.Variants.Stage1
                 surroundingTrees.SetActive(false);
 
             Skybox.DaySky();
+            /*
             fog.fogColorStart.value = new Color32(117, 154, 255, 7);
             fog.fogColorMid.value = new Color32(111, 196, 248, 45);
             fog.fogColorEnd.value = new Color32(117, 154, 255, 150);
             fog.skyboxStrength.value = 0.26f;
+            */
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             var aurora = GameObject.Find("mdlSnowyForestAurora");
 
@@ -124,8 +126,8 @@ namespace StageAesthetic.Variants.Stage1
             if (surroundingTrees)
                 surroundingTrees.SetActive(false);
             fog.fogColorStart.value = new Color32(66, 66, 66, 0);
-            fog.fogColorMid.value = new Color32(62, 18, 24, 50);
-            fog.fogColorEnd.value = new Color32(180, 74, 61, 120);
+            fog.fogColorMid.value = new Color32(42, 18, 24, 50);
+            fog.fogColorEnd.value = new Color32(140, 74, 61, 120);
             fog.skyboxStrength.value = 0.5f;
             fog.fogOne.value = 0.12f;
             fog.fogIntensity.overrideState = true;

--- a/SA.Content/Variants/Stage1/TitanicPlains.cs
+++ b/SA.Content/Variants/Stage1/TitanicPlains.cs
@@ -12,13 +12,14 @@ namespace StageAesthetic.Variants.Stage1
             Skybox.SunsetSky();
 
             fog.fogColorStart.value = new Color32(66, 66, 66, 50);
-            fog.fogColorMid.value = new Color32(62, 18, 44, 126);
-            fog.fogColorEnd.value = new Color32(123, 74, 61, 200);
+            fog.fogColorMid.value = new Color32(62, 18, 44, 150);
+            fog.fogColorEnd.value = new Color32(123, 74, 61, 255);
             fog.skyboxStrength.value = 0.02f;
-            fog.fogOne.value = 0.12f;
             fog.fogIntensity.overrideState = true;
             fog.fogIntensity.value = 1.1f;
-            fog.fogPower.value = 0.8f;
+            fog.fogPower.value = 0.5f;
+            fog.fogZero.value = -0.02f;
+            fog.fogOne.value = 0.05f;
 
             GameObject weather = GameObject.Find("Weather, Golemplains");
             if (weather)

--- a/SA.Content/Variants/Stage1/TitanicPlains.cs
+++ b/SA.Content/Variants/Stage1/TitanicPlains.cs
@@ -31,13 +31,13 @@ namespace StageAesthetic.Variants.Stage1
         {
             AddRain(RainType.Typhoon);
             fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
-            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 0.5f;
+            fog.fogPower.value = 1.5f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
-            fog.skyboxStrength.value = 0.03f;
-            fog.fogIntensity.value = 0.88f;
+            fog.skyboxStrength.value = 0f;
+            fog.fogIntensity.value = 1f;
 
             var lightBase = GameObject.Find("Weather, Golemplains").transform;
             var sunTransform = lightBase.Find("Directional Light (SUN)");

--- a/SA.Content/Variants/Stage1/TitanicPlains.cs
+++ b/SA.Content/Variants/Stage1/TitanicPlains.cs
@@ -30,10 +30,10 @@ namespace StageAesthetic.Variants.Stage1
         public static void Overcast(RampFog fog, string scenename)
         {
             AddRain(RainType.Typhoon);
-            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 0.95f);
             fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 1.5f;
+            fog.fogPower.value = 2f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
             fog.skyboxStrength.value = 0f;

--- a/SA.Content/Variants/Stage1/TitanicPlains.cs
+++ b/SA.Content/Variants/Stage1/TitanicPlains.cs
@@ -29,12 +29,15 @@ namespace StageAesthetic.Variants.Stage1
 
         public static void Overcast(RampFog fog, string scenename)
         {
-            fog.fogColorStart.value = new Color32(34, 45, 62, 18);
-            fog.fogColorMid.value = new Color32(72, 84, 103, 165);
-            fog.fogColorEnd.value = new Color32(97, 109, 129, 200);
-            fog.skyboxStrength.value = 0.075f;
-            fog.fogPower.value = 0.35f;
-            fog.fogOne.value = 0.108f;
+            AddRain(RainType.Typhoon);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
+            fog.fogPower.value = 0.5f;
+            fog.fogZero.value = -0.02f;
+            fog.fogOne.value = 0.025f;
+            fog.skyboxStrength.value = 0.03f;
+            fog.fogIntensity.value = 0.88f;
 
             var lightBase = GameObject.Find("Weather, Golemplains").transform;
             var sunTransform = lightBase.Find("Directional Light (SUN)");
@@ -43,7 +46,6 @@ namespace StageAesthetic.Variants.Stage1
             sunLight.intensity = 1.5f;
             sunLight.shadowStrength = 0.7f;
             sunTransform.localEulerAngles = new Vector3(50, 17, 270);
-            AddRain(RainType.Rainstorm);
             if (scenename == "golemplains")
             {
                 GameObject wind = GameObject.Find("WindZone");

--- a/SA.Content/Variants/Stage1/VerdantFalls.cs
+++ b/SA.Content/Variants/Stage1/VerdantFalls.cs
@@ -1,12 +1,23 @@
 using UnityEngine;
-using UnityEngine.AddressableAssets;
-using UnityEngine.Rendering.PostProcessing;
-using Object = UnityEngine.Object;
 
 namespace StageAesthetic.Variants.Stage1
 {
     internal class VerdantFalls
     {
+
+        public static void Sunny(RampFog fog)
+        {
+            GameObject.Find("Directional Light (SUN)").GetComponent<Light>().color = new Color(0.9333f, 0.8275f, 0.3361f, 1);
+            Skybox.DaySky();
+        }
+
+        public static void Purple(RampFog fog)
+        {
+            Skybox.VoidSky();
+            GameObject.Find("TLTerrainOuterDistant").SetActive(false);
+
+            AddSnow(SnowType.Moderate);
+        }
         /*
         // this gets most of the objects in the map though there's crates and maybe a few minor things that arent covered
         public static void Falls(Material terrainMat, Material detailMat, Material detailMat2, Material detailMat3, Color32 color)

--- a/SA.Content/Variants/Stage2/AphelianSanctuary.cs
+++ b/SA.Content/Variants/Stage2/AphelianSanctuary.cs
@@ -14,7 +14,7 @@ namespace StageAesthetic.Variants.Stage2
             Skybox.NightSky();
             var terrain = GameObject.Find("HOLDER: Terrain").transform;
             var terrain2 = terrain.Find("mdlAncientLoft_Terrain");
-            var sun = terrain2.Find("Sun").gameObject;
+            var sun = terrain2.Find("AL_Sun").gameObject;
             sun.SetActive(false);
             var fog1 = GameObject.Find("HOLDER: Cards");
             fog1.SetActive(false);
@@ -52,8 +52,8 @@ namespace StageAesthetic.Variants.Stage2
             sun.SetActive(false);
             var fog1 = GameObject.Find("HOLDER: Cards");
             fog1.SetActive(false);
-            var fog2 = GameObject.Find("DeepFog");
-            fog2.SetActive(false);
+            // var fog2 = GameObject.Find("DeepFog");
+            // fog2.SetActive(false);
             VanillaFoliage();
         }
 

--- a/SA.Content/Variants/Stage2/AphelianSanctuary.cs
+++ b/SA.Content/Variants/Stage2/AphelianSanctuary.cs
@@ -29,13 +29,14 @@ namespace StageAesthetic.Variants.Stage2
             Skybox.SunsetSky();
 
             fog.fogColorStart.value = new Color32(66, 66, 66, 50);
-            fog.fogColorMid.value = new Color32(62, 18, 44, 126);
-            fog.fogColorEnd.value = new Color32(123, 74, 61, 200);
-            fog.skyboxStrength.value = 0.56f;
-            fog.fogOne.value = 0.12f;
+            fog.fogColorMid.value = new Color32(62, 18, 44, 150);
+            fog.fogColorEnd.value = new Color32(123, 74, 61, 255);
+            fog.skyboxStrength.value = 0.1f;
             fog.fogIntensity.overrideState = true;
             fog.fogIntensity.value = 1f;
-            fog.fogPower.value = 0.8f;
+            fog.fogPower.value = 0.5f;
+            fog.fogZero.value = -0.02f;
+            fog.fogOne.value = 0.05f;
 
             var fog2 = GameObject.Find("DeepFog");
             fog2.SetActive(false);
@@ -47,9 +48,7 @@ namespace StageAesthetic.Variants.Stage2
         {
             GameObject.Find("Directional Light (SUN)").gameObject.SetActive(false);
             Skybox.SingularitySky();
-            var terrain = GameObject.Find("HOLDER: Terrain").transform;
-            var terrain2 = terrain.Find("mdlAncientLoft_Terrain");
-            var sun = terrain2.Find("Sun").gameObject;
+            var sun = GameObject.Find("AL_Sun").gameObject;
             sun.SetActive(false);
             var fog1 = GameObject.Find("HOLDER: Cards");
             fog1.SetActive(false);

--- a/SA.Content/Variants/Stage2/DryBasin.cs
+++ b/SA.Content/Variants/Stage2/DryBasin.cs
@@ -1,4 +1,5 @@
-﻿using FRCSharp;
+﻿/*
+using FRCSharp;
 using UnityEngine;
 using UnityEngine.Rendering.PostProcessing;
 
@@ -106,3 +107,4 @@ namespace StageAesthetic.Variants.Stage2
         }
     }
 }
+*/

--- a/SA.Content/Variants/Stage2/WetlandAspect.cs
+++ b/SA.Content/Variants/Stage2/WetlandAspect.cs
@@ -36,9 +36,9 @@ namespace StageAesthetic.Variants.Stage2
         {
             Skybox.SunsetSky();
             fog.fogColorStart.value = new Color32(66, 66, 66, 50);
-            fog.fogColorMid.value = new Color32(62, 18, 44, 100);
-            fog.fogColorEnd.value = new Color32(123, 74, 61, 150);
-            fog.skyboxStrength.value = 0.56f;
+            fog.fogColorMid.value = new Color32(62, 18, 44, 150);
+            fog.fogColorEnd.value = new Color32(123, 74, 61, 255);
+            fog.skyboxStrength.value = 0.1f;
             fog.fogOne.value = 0.12f;
             fog.fogIntensity.overrideState = true;
             fog.fogIntensity.value = 1f;

--- a/SA.Content/Variants/Stage3/FogboundLagoon.cs
+++ b/SA.Content/Variants/Stage3/FogboundLagoon.cs
@@ -64,7 +64,7 @@ namespace StageAesthetic.Variants.Stage3
             fog.fogColorStart.value = new Color32(140, 117, 150, 37);
             fog.fogColorMid.value = new Color32(84, 89, 117, 50);
             fog.fogColorEnd.value = new Color32(74, 87, 91, 255);
-            fog.skyboxStrength.value = 0.015f;
+            fog.skyboxStrength.value = 0f;
             fog.fogZero.value = -0.12f;
             cg.SetAllOverridesTo(true);
             cg.colorFilter.value = new Color32(136, 157, 162, 255);

--- a/SA.Content/Variants/Stage3/RallypointDelta.cs
+++ b/SA.Content/Variants/Stage3/RallypointDelta.cs
@@ -3,7 +3,6 @@ using System;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.Rendering.PostProcessing;
-using static UnityEngine.Experimental.TerrainAPI.TerrainUtility;
 using Object = UnityEngine.Object;
 
 namespace StageAesthetic.Variants.Stage3

--- a/SA.Content/Variants/Stage3/RallypointDelta.cs
+++ b/SA.Content/Variants/Stage3/RallypointDelta.cs
@@ -88,9 +88,9 @@ namespace StageAesthetic.Variants.Stage3
         {
             Skybox.SunsetSky();
             fog.fogColorStart.value = new Color32(66, 66, 66, 50);
-            fog.fogColorMid.value = new Color32(62, 18, 28, 100);
-            fog.fogColorEnd.value = new Color32(160, 74, 61, 150);
-            fog.skyboxStrength.value = 0.35f;
+            fog.fogColorMid.value = new Color32(62, 18, 28, 150);
+            fog.fogColorEnd.value = new Color32(160, 74, 61, 255);
+            fog.skyboxStrength.value = 0.1f;
             fog.fogOne.value = 0.12f;
             fog.fogIntensity.overrideState = true;
             fog.fogIntensity.value = 1f;

--- a/SA.Content/Variants/Stage3/RallypointDelta.cs
+++ b/SA.Content/Variants/Stage3/RallypointDelta.cs
@@ -17,24 +17,28 @@ namespace StageAesthetic.Variants.Stage3
 
         public static void Overcast(RampFog fog, PostProcessVolume volume)
         {
-            fog.fogColorStart.value = new Color32(47, 52, 62, 75);
-            fog.fogColorMid.value = new Color32(72, 80, 98, 200);
-            fog.fogColorEnd.value = new Color32(90, 101, 119, 255);
-            fog.skyboxStrength.value = 0f;
-            fog.fogZero.value = -0.05f;
-            fog.fogPower.value = 0.75f;
-            fog.fogOne.value = 0.2f;
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
+            fog.fogPower.value = 0.5f;
+            fog.fogZero.value = -0.02f;
+            fog.fogOne.value = 0.025f;
+            fog.skyboxStrength.value = 0.03f;
+            fog.fogIntensity.value = 0.88f;
+
             var sun = GameObject.Find("Directional Light (SUN)");
             var sunLight = Object.Instantiate(GameObject.Find("Directional Light (SUN)")).GetComponent<Light>();
             sun.SetActive(false);
             sun.name = "Shitty Not Working Sun";
+            var water = Main.rpdTitanicWaterMat;
             GameObject.Find("HOLDER: Skybox").transform.Find("Water").localPosition = new Vector3(-1260, -66, 0);
+            GameObject.Find("HOLDER: Skybox").transform.GetChild(0).GetComponent<MeshRenderer>().sharedMaterial = water;
             sunLight.color = Color.gray;
             sunLight.intensity = 1.3f;
             sunLight.name = "Directional Light (SUN)";
-            AddRain(RainType.Monsoon);
+
             DisableRallypointSnow();
-            AddSnow(SnowType.Light, 250f);
+            AddSnow(SnowType.Gigachad, 250f);
             var wind = GameObject.Find("WindZone");
             wind.transform.eulerAngles = new Vector3(30, 20, 0);
             var windZone = wind.GetComponent<WindZone>();

--- a/SA.Content/Variants/Stage3/RallypointDelta.cs
+++ b/SA.Content/Variants/Stage3/RallypointDelta.cs
@@ -17,10 +17,10 @@ namespace StageAesthetic.Variants.Stage3
 
         public static void Overcast(RampFog fog, PostProcessVolume volume)
         {
-            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 0.95f);
             fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 1.5f;
+            fog.fogPower.value = 2f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
             fog.skyboxStrength.value = 0f;

--- a/SA.Content/Variants/Stage3/RallypointDelta.cs
+++ b/SA.Content/Variants/Stage3/RallypointDelta.cs
@@ -18,13 +18,13 @@ namespace StageAesthetic.Variants.Stage3
         public static void Overcast(RampFog fog, PostProcessVolume volume)
         {
             fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
-            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 0.5f;
+            fog.fogPower.value = 1.5f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
-            fog.skyboxStrength.value = 0.03f;
-            fog.fogIntensity.value = 0.88f;
+            fog.skyboxStrength.value = 0f;
+            fog.fogIntensity.value = 1f;
 
             var sun = GameObject.Find("Directional Light (SUN)");
             var sunLight = Object.Instantiate(GameObject.Find("Directional Light (SUN)")).GetComponent<Light>();

--- a/SA.Content/Variants/Stage3/ScorchedAcres.cs
+++ b/SA.Content/Variants/Stage3/ScorchedAcres.cs
@@ -10,8 +10,8 @@ namespace StageAesthetic.Variants.Stage3
         public static void Sunset(RampFog fog, ColorGrading cgrade)
         {
             fog.fogColorStart.value = new Color32(86, 66, 66, 50);
-            fog.fogColorMid.value = new Color32(82, 18, 44, 60);
-            fog.fogColorEnd.value = new Color32(143, 74, 91, 160);
+            fog.fogColorMid.value = new Color32(82, 18, 44, 120);
+            fog.fogColorEnd.value = new Color32(143, 74, 91, 255);
             fog.skyboxStrength.value = 0.1f;
             fog.fogOne.value = 0.12f;
             fog.fogIntensity.overrideState = true;

--- a/SA.Content/Variants/Stage3/ScorchedAcres.cs
+++ b/SA.Content/Variants/Stage3/ScorchedAcres.cs
@@ -2,7 +2,6 @@
 using UnityEngine.AddressableAssets;
 using UnityEngine.Rendering.PostProcessing;
 using UnityEngine.SceneManagement;
-using static UnityEngine.Experimental.TerrainAPI.TerrainUtility;
 
 namespace StageAesthetic.Variants.Stage3
 {

--- a/SA.Content/Variants/Stage3/SulfurPools.cs
+++ b/SA.Content/Variants/Stage3/SulfurPools.cs
@@ -3,7 +3,6 @@ using System;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.Rendering.PostProcessing;
-using static UnityEngine.Experimental.TerrainAPI.TerrainUtility;
 using Object = UnityEngine.Object;
 
 namespace StageAesthetic.Variants.Stage3

--- a/SA.Content/Variants/Stage4/AbyssalDepths.cs
+++ b/SA.Content/Variants/Stage4/AbyssalDepths.cs
@@ -65,6 +65,8 @@ namespace StageAesthetic.Variants.Stage4
 
         public static void Orange(RampFog fog)
         {
+            Skybox.DaySky();
+            /*
             fog.fogColorStart.value = new Color32(66, 66, 66, 50);
             fog.fogColorMid.value = new Color32(44, 18, 62, 100);
             fog.fogColorEnd.value = new Color32(61, 74, 123, 150);
@@ -73,9 +75,9 @@ namespace StageAesthetic.Variants.Stage4
             fog.fogIntensity.overrideState = true;
             fog.fogIntensity.value = 1f;
             fog.fogPower.value = 0.75f;
-
+            */
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
-            sunLight.color = new Color(1f, 1f, 0.75f, 1f);
+            sunLight.color = new Color32(77, 188, 175, 255);
             sunLight.intensity = 1f;
             sunLight.transform.eulerAngles = new Vector3(70f, 19.64314f, 9.985f);
             sunLight.shadowStrength = 0.75f;

--- a/SA.Content/Variants/Stage4/SirensCall.cs
+++ b/SA.Content/Variants/Stage4/SirensCall.cs
@@ -87,13 +87,13 @@ namespace StageAesthetic.Variants.Stage4
         {
             AddRain(RainType.Typhoon);
             fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
-            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 0.5f;
+            fog.fogPower.value = 1.5f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
-            fog.skyboxStrength.value = 0.03f;
-            fog.fogIntensity.value = 0.88f;
+            fog.skyboxStrength.value = 0f;
+            fog.fogIntensity.value = 1f;
 
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             sunLight.color = new Color32(191, 191, 191, 255);

--- a/SA.Content/Variants/Stage4/SirensCall.cs
+++ b/SA.Content/Variants/Stage4/SirensCall.cs
@@ -47,17 +47,12 @@ namespace StageAesthetic.Variants.Stage4
 
         public static void Sunny(RampFog fog)
         {
-            fog.fogColorStart.value = new Color32(53, 66, 82, 18);
-            fog.fogColorMid.value = new Color32(103, 67, 64, 154);
-            fog.fogColorEnd.value = new Color32(146, 176, 255, 255);
-            fog.fogOne.value = 0.2f;
-            fog.fogZero.value = -0.05f;
-            fog.skyboxStrength.value = 0.25f;
+            Skybox.DaySky();
             var lightBase = GameObject.Find("Weather, Shipgraveyard").transform;
             var sunTransform = lightBase.Find("Directional Light (SUN)");
             Light sunLight = sunTransform.gameObject.GetComponent<Light>();
             sunLight.color = new Color32(255, 239, 223, 255);
-            sunLight.intensity = 2f;
+            sunLight.intensity = 1.5f;
             sunLight.shadowStrength = 0.75f;
             sunTransform.localEulerAngles = new Vector3(33, 0, 0);
             var meshList = Object.FindObjectsOfType(typeof(MeshRenderer)) as MeshRenderer[];
@@ -90,21 +85,21 @@ namespace StageAesthetic.Variants.Stage4
 
         public static void Overcast(RampFog fog)
         {
-            fog.fogColorStart.value = new Color32(47, 52, 62, 75);
-            fog.fogColorMid.value = new Color32(72, 80, 98, 200);
-            fog.fogColorEnd.value = new Color32(90, 101, 119, 255);
-            fog.skyboxStrength.value = 0.02f;
-            fog.fogPower.value = 0.75f;
-            fog.fogIntensity.value = 1f;
-            fog.fogZero.value = -0.05f;
-            fog.fogOne.value = 0.169f;
+            AddRain(RainType.Typhoon);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
+            fog.fogPower.value = 0.5f;
+            fog.fogZero.value = -0.02f;
+            fog.fogOne.value = 0.025f;
+            fog.skyboxStrength.value = 0.03f;
+            fog.fogIntensity.value = 0.88f;
 
             var sunLight = GameObject.Find("Directional Light (SUN)").GetComponent<Light>();
             sunLight.color = new Color32(191, 191, 191, 255);
-            sunLight.intensity = 2f;
+            sunLight.intensity = 1.25f;
             sunLight.shadowStrength = 0.5f;
 
-            AddRain(RainType.Typhoon);
             var meshList = Object.FindObjectsOfType(typeof(MeshRenderer)) as MeshRenderer[];
             foreach (MeshRenderer mr in meshList)
             {

--- a/SA.Content/Variants/Stage4/SirensCall.cs
+++ b/SA.Content/Variants/Stage4/SirensCall.cs
@@ -86,10 +86,10 @@ namespace StageAesthetic.Variants.Stage4
         public static void Overcast(RampFog fog)
         {
             AddRain(RainType.Typhoon);
-            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 0.95f);
             fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 1.5f;
+            fog.fogPower.value = 2f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
             fog.skyboxStrength.value = 0f;

--- a/SA.Content/Variants/Stage4/SunderedGrove.cs
+++ b/SA.Content/Variants/Stage4/SunderedGrove.cs
@@ -58,13 +58,13 @@ namespace StageAesthetic.Variants.Stage4
             sunLight.intensity = 1.5f;
             AddRain(RainType.Typhoon);
             fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
-            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 0.5f;
+            fog.fogPower.value = 1.5f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
-            fog.skyboxStrength.value = 0.03f;
-            fog.fogIntensity.value = 0.88f;
+            fog.skyboxStrength.value = 0f;
+            fog.fogIntensity.value = 1f;
 
             // cgrade.colorFilter.value = new Color32(148, 206, 183, 255);
             //cgrade.colorFilter.overrideState = true;

--- a/SA.Content/Variants/Stage4/SunderedGrove.cs
+++ b/SA.Content/Variants/Stage4/SunderedGrove.cs
@@ -55,15 +55,16 @@ namespace StageAesthetic.Variants.Stage4
             var sunTransform = lightBase.Find("Directional Light (SUN)");
             Light sunLight = sunTransform.gameObject.GetComponent<Light>();
             sunLight.color = new Color32(77, 188, 175, 255);
-            sunLight.intensity = 3f;
-            fog.fogColorStart.value = new Color32(31, 46, 63, 50);
-            fog.fogColorMid.value = new Color(0.205f, 0.269f, 0.288f, 0.76f);
-            fog.fogColorEnd.value = new Color32(71, 82, 88, 255);
-            fog.skyboxStrength.value = 0.02f;
-            fog.fogPower.value = 0.35f;
-            fog.fogIntensity.value = 0.88f;
+            sunLight.intensity = 1.5f;
+            AddRain(RainType.Typhoon);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
+            fog.fogPower.value = 0.5f;
             fog.fogZero.value = -0.02f;
-            fog.fogOne.value = 0.05f;
+            fog.fogOne.value = 0.025f;
+            fog.skyboxStrength.value = 0.03f;
+            fog.fogIntensity.value = 0.88f;
 
             // cgrade.colorFilter.value = new Color32(148, 206, 183, 255);
             //cgrade.colorFilter.overrideState = true;
@@ -71,7 +72,6 @@ namespace StageAesthetic.Variants.Stage4
             var rain = lightBase.Find("CameraRelative").gameObject;
             rain.SetActive(false);
 
-            AddRain(RainType.Typhoon);
             VanillaFoliage();
         }
 

--- a/SA.Content/Variants/Stage4/SunderedGrove.cs
+++ b/SA.Content/Variants/Stage4/SunderedGrove.cs
@@ -57,10 +57,10 @@ namespace StageAesthetic.Variants.Stage4
             sunLight.color = new Color32(77, 188, 175, 255);
             sunLight.intensity = 1.5f;
             AddRain(RainType.Typhoon);
-            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 0.95f);
             fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 1.5f;
+            fog.fogPower.value = 2f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
             fog.skyboxStrength.value = 0f;

--- a/SA.Content/Variants/Stage5/HelminthHatchery.cs
+++ b/SA.Content/Variants/Stage5/HelminthHatchery.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.Rendering.PostProcessing;
+using Object = UnityEngine.Object;
+
+namespace StageAesthetic.Variants.Stage5
+{
+  internal class HelminthHatchery
+  {
+    public static void VanillaChanges(RampFog fog)
+    {
+      fog.fogColorStart.value = new Color(0.5453f, 0.4527f, 0.3988f, 0.15f);
+      GameObject cameraParticles = GameObject.Find("CAMERA PARTICLES: AshParticles");
+      if (cameraParticles)
+      {
+        cameraParticles.transform.GetChild(0).gameObject.SetActive(false);
+      }
+    }
+
+    public static void Lunar(RampFog fog)
+    {
+      GameObject cameraParticles = GameObject.Find("CAMERA PARTICLES: AshParticles");
+      if (cameraParticles)
+      {
+        cameraParticles.transform.GetChild(0).gameObject.SetActive(false);
+      }
+      // fog end 0.3208 0.1234 0.1044 1
+      // fog mid 0.5176 0.3338 0.2706 0.4471
+      // fog start 0.7453 0.3527 0.2988 0
+      fog.fogColorEnd.value = new Color(0.5f, 0.5f, 0.6f, 1);
+      fog.fogColorMid.value = new Color(0f, 0.42f, 0.57f, 0.4471f);
+      fog.fogColorStart.value = new Color(0f, 0.45f, 0.47f, 0.1f);
+      // fog intensity 0.588
+      // fog one 0.601
+      // fog power 2.27
+      // fog zero -0.48
+      // skybox strength 0.092
+      // 0.9608 0.4704 0 1 lava
+      // HRSection temple stuff
+      // HRTerrain terrain
+      // HRWorm da worm
+      // HRRock
+      // HRLava
+      // "FLOWMAP", "FRESNEL_EMISSION", "SPLATMAP", "USE_VERTEX_COLORS"
+      Material terrainMat = new Material(Main.helminthTerrainMat);
+      Texture2D blueTex = Main.moonTerrainMat.GetTexture("_BlueChannelTex") as Texture2D;
+      Texture2D greenTex = Main.moonTerrainMat.GetTexture("_GreenChannelTex") as Texture2D;
+      terrainMat.SetTexture("_GreenChannelTex", blueTex);
+      terrainMat.SetTexture("_BlueChannelTex", greenTex);
+      // HRFireStatic
+      ParticleSystemRenderer[] fireList = Resources.FindObjectsOfTypeAll(typeof(ParticleSystemRenderer)) as ParticleSystemRenderer[];
+      foreach (ParticleSystemRenderer psr in fireList)
+      {
+        GameObject fireBase = psr.gameObject;
+        if (fireBase != null)
+        {
+          if (fireBase.name.Contains("HRFireStatic") && psr.sharedMaterial)
+          {
+            psr.sharedMaterial = Main.blueFireMat;
+            if (psr.transform.GetChild(0))
+            {
+              psr.transform.GetChild(0).GetComponent<Light>().color = new Color(0f, 0.4704f, 0.9608f, 1);
+            }
+          }
+        }
+      }
+      MeshRenderer[] meshList = Resources.FindObjectsOfTypeAll(typeof(MeshRenderer)) as MeshRenderer[];
+      foreach (MeshRenderer renderer in meshList)
+      {
+        GameObject meshBase = renderer.gameObject;
+        if (meshBase != null)
+        {
+          if ((meshBase.name.Contains("HRSection") || meshBase.name.Contains("HRGroundCover")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = Main.moonDetailMat2;
+          }
+          if (((meshBase.name.Contains("HRTerrain") && !meshBase.name.Contains("Lava")) || meshBase.name.Contains("HRStalagmitesCombined")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = terrainMat;
+          }
+          if (meshBase.name.Contains("HRWorm") && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = Main.moonDetailMat3;
+          }
+          if ((meshBase.name.Contains("HRRock") || meshBase.name.Contains("Volcanoid") || meshBase.name.Contains("HRObisidian")) && renderer.sharedMaterial)
+          {
+            renderer.sharedMaterial = Main.moonDetailMat;
+          }
+        }
+      }
+    }
+  }
+}

--- a/SA.Content/Variants/Stage5/HelminthHatchery.cs
+++ b/SA.Content/Variants/Stage5/HelminthHatchery.cs
@@ -1,7 +1,4 @@
 using UnityEngine;
-using UnityEngine.AddressableAssets;
-using UnityEngine.Rendering.PostProcessing;
-using Object = UnityEngine.Object;
 
 namespace StageAesthetic.Variants.Stage5
 {

--- a/SA.Content/Variants/Stage5/SkyMeadow.cs
+++ b/SA.Content/Variants/Stage5/SkyMeadow.cs
@@ -42,22 +42,22 @@ namespace StageAesthetic.Variants.Stage5
 
         public static void Overcast(RampFog fog)
         {
-            fog.fogColorStart.value = new Color32(31, 46, 63, 50);
-            fog.fogColorMid.value = new Color(0.205f, 0.269f, 0.288f, 0.76f);
-            fog.fogColorEnd.value = new Color32(71, 82, 88, 255);
-            fog.skyboxStrength.value = 0.02f;
-            fog.fogPower.value = 0.35f;
-            fog.fogIntensity.value = 0.88f;
+            AddRain(RainType.Typhoon);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
+            fog.fogPower.value = 0.5f;
             fog.fogZero.value = -0.02f;
-            fog.fogOne.value = 0.05f;
+            fog.fogOne.value = 0.025f;
+            fog.skyboxStrength.value = 0.03f;
+            fog.fogIntensity.value = 0.88f;
 
             var lightBase = GameObject.Find("HOLDER: Weather Set 1").transform;
             var sunTransform = lightBase.Find("Directional Light (SUN)");
             var sunLight = sunTransform.gameObject.GetComponent<Light>();
             sunLight.color = new Color32(77, 188, 175, 255);
-            sunLight.intensity = 1.5f;
+            sunLight.intensity = 1f;
             sunLight.shadowStrength = 0.6f;
-            AddRain(RainType.Typhoon);
             var wind = GameObject.Find("WindZone");
             wind.transform.eulerAngles = new Vector3(30, 20, 0);
             var windZone = wind.GetComponent<WindZone>();

--- a/SA.Content/Variants/Stage5/SkyMeadow.cs
+++ b/SA.Content/Variants/Stage5/SkyMeadow.cs
@@ -43,14 +43,14 @@ namespace StageAesthetic.Variants.Stage5
         public static void Overcast(RampFog fog)
         {
             AddRain(RainType.Typhoon);
-            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 1);
-            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.4f);
+            fog.fogColorEnd.value = new Color(0.3272f, 0.3711f, 0.4057f, 0.95f);
+            fog.fogColorMid.value = new Color(0.2864f, 0.2667f, 0.3216f, 0.55f);
             fog.fogColorStart.value = new Color(0.2471f, 0.2471f, 0.2471f, 0.05f);
-            fog.fogPower.value = 0.5f;
+            fog.fogPower.value = 2f;
             fog.fogZero.value = -0.02f;
             fog.fogOne.value = 0.025f;
-            fog.skyboxStrength.value = 0.03f;
-            fog.fogIntensity.value = 0.88f;
+            fog.skyboxStrength.value = 0f;
+            fog.fogIntensity.value = 1f;
 
             var lightBase = GameObject.Find("HOLDER: Weather Set 1").transform;
             var sunTransform = lightBase.Find("Directional Light (SUN)");

--- a/SA.Content/Variants/Stage5/SlumberingSatellite.cs
+++ b/SA.Content/Variants/Stage5/SlumberingSatellite.cs
@@ -1,4 +1,5 @@
-﻿using FRCSharp;
+﻿/*
+using FRCSharp;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -158,3 +159,4 @@ namespace StageAesthetic.Variants.Stage5
         }
     }
 }
+*/

--- a/SA.Content/Variants/Utils.cs
+++ b/SA.Content/Variants/Utils.cs
@@ -370,37 +370,6 @@ namespace StageAesthetic.Variants
             UnityEngine.Object.Instantiate(sand, Vector3.zero, Quaternion.identity);
         }
 
-        public static void PlaySound(SoundType soundType)
-        {
-            if (!WeatherSounds.Value)
-            {
-                return;
-            }
-
-            var soundToPlay = soundType switch
-            {
-                SoundType.DayNature => "Play_SA_birds",
-                SoundType.Rain => "Play_SA_rain",
-                SoundType.Storm => "Play_SA_storm",
-                SoundType.NightNature => "Play_SA_night",
-                SoundType.WaterStream => "Play_SA_water",
-                SoundType.Wind => "Play_SA_wind",
-                _ => "Play_SA_wind"
-            };
-
-            Util.PlaySound(soundToPlay, RoR2Application.instance.GetComponentInChildren<MusicController>().gameObject);
-        }
-
-        public static void StopSounds()
-        {
-            var musicController = RoR2Application.instance.GetComponentInChildren<MusicController>().gameObject;
-            Util.PlaySound("Stop_SA_birds", musicController);
-            Util.PlaySound("Stop_SA_rain", musicController);
-            Util.PlaySound("Stop_SA_storm", musicController);
-            Util.PlaySound("Stop_SA_night", musicController);
-            Util.PlaySound("Stop_SA_water", musicController);
-            Util.PlaySound("Stop_SA_wind", musicController);
-        }
     }
 
     // for compat


### PR DESCRIPTION
- Updated for SOTS
- Removed ambient sound stuff (couldn't get the mod to load with it)
- Added new variants for SOTS
- Helminth now has Lunar
- Abodes now has Verdant and Abandoned
- Altar now has Verdant and Helminth
- Treeborn now has Night, Sunny, and Overcast
- Verdant now has Sunny and Purple
- Tweaks to existing Skyboxes and Variants
- Overcast is now more intense
- Siphoned material fixes
- Sunset now uses Scorched Acres post processing (the skybox is messed up after the update so I needed to cover it up)